### PR TITLE
Switch unicode-linebreak to xi-unicode for ~25% faster debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rustybuzz = "0.5"
 swash = "0.1"
 sys-locale = "0.2"
 unicode-bidi = "0.3"
-unicode-linebreak = "0.1"
+xi-unicode = "0.3.0"
 unicode-script = "0.5"
 
 [workspace]

--- a/src/font/matches.rs
+++ b/src/font/matches.rs
@@ -243,7 +243,7 @@ impl<'a> FontMatches<'a> {
         let mut words = Vec::new();
 
         let mut start_word = 0;
-        for (end_lb, _) in unicode_linebreak::linebreaks(span) {
+        for (end_lb, _) in xi_unicode::LineBreakIterator::new(span) {
             let mut start_lb = end_lb;
             for (i, c) in span[start_word..end_lb].char_indices() {
                 if start_word + i == end_lb {


### PR DESCRIPTION
Further details in the original issue: https://github.com/pop-os/cosmic-text/issues/2