### PR TITLE
Clippy fixes and editor-orbclient scroll drag selection fixes and middle mouse scroll fixes

### DIFF
--- a/examples/editor-orbclient/src/main.rs
+++ b/examples/editor-orbclient/src/main.rs
@@ -98,19 +98,15 @@ fn main() {
     let mut mouse_x = -1;
     let mut mouse_y = -1;
     let mut mouse_left = false;
-    let mut shape_me = true;
+
+    //Lets do this once and rely on events for the rest.
+    buffer.shape_until_cursor();
 
     loop {
         let font_size = buffer.metrics().font_size;
         let line_height = buffer.metrics().line_height;
 
         let mut force_drag = true;
-
-        //lets do this once and rely on the events to do the rest.
-        if shape_me {
-            buffer.shape_until_cursor();
-            shape_me = false;
-        }
 
         if buffer.redraw {
             let instant = Instant::now();

--- a/src/font/cache.rs
+++ b/src/font/cache.rs
@@ -10,7 +10,12 @@ pub struct CacheKey {
 }
 
 impl CacheKey {
-    pub fn new(font_id: fontdb::ID, glyph_id: u16, font_size: i32, pos: (f32, f32)) -> (Self, i32, i32) {
+    pub fn new(
+        font_id: fontdb::ID,
+        glyph_id: u16,
+        font_size: i32,
+        pos: (f32, f32),
+    ) -> (Self, i32, i32) {
         let (x, x_bin) = SubpixelBin::new(pos.0);
         let (y, y_bin) = SubpixelBin::new(pos.1);
         (
@@ -54,6 +59,7 @@ impl SubpixelBin {
                 (trunc - 1, Self::Zero)
             }
         } else {
+            #[allow(clippy::collapsible_else_if)]
             if fract < 0.125 {
                 (trunc, Self::Zero)
             } else if fract < 0.375 {

--- a/src/font/matches.rs
+++ b/src/font/matches.rs
@@ -132,7 +132,7 @@ impl<'a> FontMatches<'a> {
             &self.fonts,
             &["Fira Sans", "Fira Mono"],
             scripts,
-            &self.locale
+            self.locale
         );
 
         let (mut glyphs, mut missing) = self.shape_fallback(
@@ -306,7 +306,7 @@ impl<'a> FontMatches<'a> {
 
             log::trace!("Line {}: '{}'", if line_rtl { "RTL" } else { "LTR" }, line);
 
-            let paragraph = unicode_bidi::Paragraph::new(&bidi, &para_info);
+            let paragraph = unicode_bidi::Paragraph::new(&bidi, para_info);
 
             let mut start = 0;
             let mut span_rtl = line_rtl;

--- a/src/font/shape.rs
+++ b/src/font/shape.rs
@@ -23,7 +23,7 @@ impl<'a> FontShapeGlyph<'a> {
         FontLayoutGlyph {
             start: self.start,
             end: self.end,
-            x: x,
+            x,
             w: x_advance,
             rtl,
             font: self.font,

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -43,10 +43,10 @@ impl FontSystem {
         Self { locale, db }
     }
 
-    pub fn matches<'a, F: Fn(&fontdb::FaceInfo) -> bool>(
-        &'a self,
+    pub fn matches<F: Fn(&fontdb::FaceInfo) -> bool>(
+        &self,
         f: F,
-    ) -> Option<FontMatches<'a>> {
+    ) -> Option<FontMatches<'_>> {
         let mut fonts = Vec::new();
         for face in self.db.faces() {
             if !f(face) {
@@ -82,5 +82,11 @@ impl FontSystem {
         } else {
             None
         }
+    }
+}
+
+impl Default for FontSystem {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
the scroll bar is no longer tied to the cursor. It now also only re-renders on event or when the mouse is held down and withing 5 pixels of the top or bottom during selection.