### PR TITLE
Make `font_matches` public for now

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -237,7 +237,7 @@ impl TextBufferLine {
 
 /// A buffer of text that is shaped and laid out
 pub struct TextBuffer<'a> {
-    font_matches: FontMatches<'a>,
+    pub font_matches: FontMatches<'a>,
     attrs: Attrs<'a>,
     lines: Vec<TextBufferLine>,
     metrics: TextMetrics,


### PR DESCRIPTION
Adds `pub` to `font_matches` so we can use it with `SwashCache` for now