### PR TITLE
Rework add_span

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -199,7 +199,7 @@ impl<'a> AttrsList<'a> {
         for (isfront, isback, rework) in rework_spans {
             let ranges = match (isfront, isback) {
                 (true, false) => vec!(rework.0.start..range.start),
-                (false, true) => vec!(range.end..rework.0.end),
+                (false, true) => vec!(range.end + 1..rework.0.end),
                 _ => vec!(rework.0.start..range.start, range.end..rework.0.end),
             };
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -170,11 +170,6 @@ impl<'a> AttrsList<'a> {
 
     /// Add an attribute span, removes any previous matching parts of spans
     pub fn add_span(&mut self, range: Range<usize>, attrs: Attrs<'a>) {
-        //if range == itself then there is no range avoid adding it to save space.
-        if range.start == range.end {
-            return;
-        }
-
         //there should only be at most 2 that can be resized. the rest would be removed.
         let mut rework_spans = Vec::with_capacity(3);
         let mut i = 0;
@@ -209,9 +204,7 @@ impl<'a> AttrsList<'a> {
             };
 
             for range in ranges {
-                if range.start != range.end {
-                    self.spans.push((range, rework.1));
-                }
+                self.spans.push((range, rework.1));
             }
         }
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -170,10 +170,8 @@ impl<'a> AttrsList<'a> {
 
     /// Add an attribute span, removes any previous matching parts of spans
     pub fn add_span(&mut self, range: Range<usize>, attrs: Attrs<'a>) {
-        // Condense spans
-        //TODO: more advanced merging
-
-        let mut rework_spans = Vec::with_capacity(5);
+        //there should only be at most 2 that can be resized. the rest would be removed.
+        let mut rework_spans = Vec::with_capacity(3);
         let mut i = 0;
 
         //grab intersecting parts that are not fully intersected. remove those that are.
@@ -210,6 +208,7 @@ impl<'a> AttrsList<'a> {
             }
         }
 
+        //Finally lets add the new span. it should fit now.
         self.spans.push((range, attrs));
     }
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -187,6 +187,8 @@ impl<'a> AttrsList<'a> {
             } else if self.spans[i].0.end > range.end && self.spans[i].0.start < range.start {
                 let rework = self.spans.remove(i);
                 rework_spans.push((true, true, rework));
+            } else if self.spans[i].0.start > range.end {
+                break;
             } else {
                 i += 1;
             }
@@ -210,13 +212,16 @@ impl<'a> AttrsList<'a> {
 
         //Finally lets add the new span. it should fit now.
         self.spans.push((range, attrs));
+
+        //sort by start to speed up further additions
+        self.spans.sort_by(|a, b| a.0.start.partial_cmp(&b.0.start).unwrap())
     }
 
     /// Get the highest priority attribute span for a range
     ///
-    /// This returns the latest added span that contains the range
+    /// This returns the first span that contains the range
     pub fn get_span(&self, range: Range<usize>) -> Attrs<'a> {
-        for span in self.spans.iter().rev() {
+        for span in self.spans.iter() {
             if range.start >= span.0.start && range.end <= span.0.end {
                 return span.1;
             }

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -170,6 +170,11 @@ impl<'a> AttrsList<'a> {
 
     /// Add an attribute span, removes any previous matching parts of spans
     pub fn add_span(&mut self, range: Range<usize>, attrs: Attrs<'a>) {
+        //if range == itself then there is no range avoid adding it to save space.
+        if range.start == range.end {
+            return;
+        }
+
         //there should only be at most 2 that can be resized. the rest would be removed.
         let mut rework_spans = Vec::with_capacity(3);
         let mut i = 0;
@@ -202,9 +207,11 @@ impl<'a> AttrsList<'a> {
                 (false, true) => vec!(range.end..rework.0.end),
                 _ => vec!(rework.0.start..range.start, range.end..rework.0.end),
             };
-            
+
             for range in ranges {
-                self.spans.push((range, rework.1));
+                if range.start != range.end {
+                    self.spans.push((range, rework.1));
+                }
             }
         }
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -200,7 +200,7 @@ impl<'a> AttrsList<'a> {
         // will need to do loop handling to support this.
         for (isfront, isback, rework) in rework_spans {
             let ranges = match (isfront, isback) {
-                (true, false) => vec!(rework.0.start..range.start),
+                (true, false) => vec!(rework.0.start..range.start - 1),
                 (false, true) => vec!(range.end + 1..rework.0.end),
                 _ => vec!(rework.0.start..range.start, range.end..rework.0.end),
             };


### PR DESCRIPTION
Rework Ranges to split and change or overwrite based on old ranges to new range within add span

a playground test of it.

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=dc84119d7c4ca64743a27b947b14094f