### PR TITLE
Libcosmic example fixes

### DIFF
--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -111,10 +111,11 @@ impl Application for Window {
             .monospaced(true)
             .family(cosmic_text::Family::Monospace);
 
-        let buffer = TextBuffer::new(
+        let mut buffer = TextBuffer::new(
             &FONT_SYSTEM,
             FONT_SIZES[1 /* Body */],
         );
+        update_attrs(&mut buffer, attrs);
 
         let mut window = Window {
             theme: Theme::Dark,
@@ -173,9 +174,7 @@ impl Application for Window {
                 });
 
                 let mut buffer = self.buffer.lock().unwrap();
-                for line in buffer.lines.iter_mut() {
-                    line.set_attrs_list(AttrsList::new(self.attrs));
-                }
+                update_attrs(&mut buffer, self.attrs);
             },
             Message::Italic(italic) => {
                 self.attrs = self.attrs.style(if italic {
@@ -185,9 +184,7 @@ impl Application for Window {
                 });
 
                 let mut buffer = self.buffer.lock().unwrap();
-                for line in buffer.lines.iter_mut() {
-                    line.set_attrs_list(AttrsList::new(self.attrs));
-                }
+                update_attrs(&mut buffer, self.attrs);
             },
             Message::Monospaced(monospaced) => {
                 self.attrs = self.attrs
@@ -199,9 +196,7 @@ impl Application for Window {
                     .monospaced(monospaced);
 
                 let mut buffer = self.buffer.lock().unwrap();
-                for line in buffer.lines.iter_mut() {
-                    line.set_attrs_list(AttrsList::new(self.attrs));
-                }
+                update_attrs(&mut buffer, self.attrs);
             },
             Message::MetricsChanged(metrics) => {
                 let mut buffer = self.buffer.lock().unwrap();
@@ -265,4 +260,10 @@ impl Application for Window {
         // Uncomment to debug layout: content.explain(Color::WHITE)
         content
     }
+}
+
+fn update_attrs<'a>(buffer: &mut TextBuffer<'a>, attrs: Attrs<'a>) {
+    buffer.lines.iter_mut().for_each(|line| {
+        line.set_attrs_list(AttrsList::new(attrs));
+    });
 }

--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -3,6 +3,7 @@
 use cosmic::{
     iced::{
         self,
+        Color,
         Alignment,
         Application,
         Command,
@@ -202,10 +203,19 @@ impl Application for Window {
                 let mut buffer = self.buffer.lock().unwrap();
                 buffer.set_metrics(metrics);
             },
-            Message::ThemeChanged(theme) => match theme {
-                "Dark" => self.theme = Theme::Dark,
-                "Light" => self.theme = Theme::Light,
-                _ => (),
+            Message::ThemeChanged(theme) => {
+                self.theme = match theme {
+                    "Dark" => Theme::Dark,
+                    "Light" => Theme::Light,
+                    _ => return Command::none(),
+                };
+
+                let Color { r, g, b, a } = self.theme.palette().text;
+                let as_u8 = |component: f32| (component * 255.0) as u8;
+                self.attrs = self.attrs.color(cosmic_text::Color::rgba(as_u8(r), as_u8(g), as_u8(b), as_u8(a)));
+
+                let mut buffer = self.buffer.lock().unwrap();
+                update_attrs(&mut buffer, self.attrs);
             },
         }
 


### PR DESCRIPTION
A couple small fixes:

- Attrs weren't set on launch, this caused the initial font to render as sans and not monospace
- Set text color when theme changes. Text was still white on light theme.