### PR TITLE
Resolve size using limits

### DIFF
--- a/examples/editor-libcosmic/src/text.rs
+++ b/examples/editor-libcosmic/src/text.rs
@@ -105,6 +105,8 @@ where
     ) -> layout::Node {
         let instant = Instant::now();
 
+        let limits = limits.width(Length::Shrink).height(Length::Shrink);
+
         let shape = self.line.shape_opt().as_ref().unwrap();
 
         //TODO: can we cache this?
@@ -128,7 +130,7 @@ where
 
         log::debug!("layout {:?} in {:?}", size, instant.elapsed());
 
-        layout::Node::new(size)
+        layout::Node::new(limits.resolve(size))
     }
 
     fn draw(

--- a/examples/editor-libcosmic/src/text_box.rs
+++ b/examples/editor-libcosmic/src/text_box.rs
@@ -88,6 +88,8 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        let limits = limits.width(Length::Fill).height(Length::Fill);
+
         //TODO: allow lazy shape
         let mut editor = self.editor.lock().unwrap();
         editor.buffer.shape_until(i32::max_value());
@@ -103,7 +105,8 @@ where
         let height = layout_lines as f32 * editor.buffer.metrics().line_height as f32;
         let size = Size::new(limits.max().width, height);
         log::info!("size {:?}", size);
-        layout::Node::new(size)
+
+        layout::Node::new(limits.resolve(size))
     }
 
     fn mouse_interaction(


### PR DESCRIPTION
Limits weren't used to resolve the final layout node. This caused textbox to not Fill properly (example only rendered first line) and text to not collapse properly when resizing the application smaller.