### PR TITLE
Use `ouroboros` in `FontSystem` to avoid lifetime bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 fontdb = "0.9.3"
 log = "0.4"
+ouroboros = "0.15.5"
 rustybuzz = "0.5"
 swash = { version = "0.1", optional = true }
 sys-locale = "0.2"

--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -45,7 +45,7 @@ use self::text_box::text_box;
 mod text_box;
 
 lazy_static::lazy_static! {
-    static ref FONT_SYSTEM: FontSystem<'static> = FontSystem::new();
+    static ref FONT_SYSTEM: FontSystem = FontSystem::new();
 }
 
 static FONT_SIZES: &'static [Metrics] = &[
@@ -137,9 +137,9 @@ impl Application for Window {
 
     fn title(&self) -> String {
         if let Some(path) = &self.path_opt {
-            format!("COSMIC Text - {} - {}", FONT_SYSTEM.locale, path.display())
+            format!("COSMIC Text - {} - {}", FONT_SYSTEM.locale(), path.display())
         } else {
-            format!("COSMIC Text - {}", FONT_SYSTEM.locale)
+            format!("COSMIC Text - {}", FONT_SYSTEM.locale())
         }
     }
 

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
         -1,
         1024 * display_scale as u32,
         768 * display_scale as u32,
-        &format!("COSMIC TEXT - {}", font_system.locale),
+        &format!("COSMIC TEXT - {}", font_system.locale()),
         &[WindowFlag::Resizable],
     )
     .unwrap();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -139,7 +139,7 @@ impl fmt::Display for Metrics {
 
 /// A buffer of text that is shaped and laid out
 pub struct Buffer<'a> {
-    font_system: &'a FontSystem<'a>,
+    font_system: &'a FontSystem,
     /// Lines (or paragraphs) of text in the buffer
     pub lines: Vec<BufferLine>,
     metrics: Metrics,
@@ -153,7 +153,7 @@ pub struct Buffer<'a> {
 impl<'a> Buffer<'a> {
     /// Create a new [Buffer] with the provided [FontSystem] and [Metrics]
     pub fn new(
-        font_system: &'a FontSystem<'a>,
+        font_system: &'a FontSystem,
         metrics: Metrics,
     ) -> Self {
         let mut buffer = Self {

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -132,7 +132,7 @@ impl BufferLine {
     }
 
     /// Shape line, will cache results
-    pub fn shape<'a>(&mut self, font_system: &'a FontSystem<'a>) -> &ShapeLine {
+    pub fn shape(&mut self, font_system: &FontSystem) -> &ShapeLine {
         if self.shape_opt.is_none() {
             self.shape_opt = Some(ShapeLine::new(font_system, &self.text, &self.attrs_list));
             self.layout_opt = None;
@@ -146,7 +146,7 @@ impl BufferLine {
     }
 
     /// Layout line, will cache results
-    pub fn layout<'a>(&mut self, font_system: &'a FontSystem<'a>, font_size: i32, width: i32) -> &[LayoutLine] {
+    pub fn layout(&mut self, font_system: &FontSystem, font_size: i32, width: i32) -> &[LayoutLine] {
         if self.layout_opt.is_none() {
             let wrap_simple = self.wrap_simple;
             let shape = self.shape(font_system);

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -102,7 +102,7 @@ fn shape_fallback(
 }
 
 fn shape_run<'a>(
-    font_system: &'a FontSystem<'a>,
+    font_system: &'a FontSystem,
     line: &str,
     attrs_list: &AttrsList,
     start_run: usize,
@@ -281,7 +281,7 @@ pub struct ShapeWord {
 
 impl ShapeWord {
     pub fn new<'a>(
-        font_system: &'a FontSystem<'a>,
+        font_system: &'a FontSystem,
         line: &str,
         attrs_list: &AttrsList,
         start_word: usize,
@@ -344,7 +344,7 @@ pub struct ShapeSpan {
 
 impl ShapeSpan {
     pub fn new<'a>(
-        font_system: &'a FontSystem<'a>,
+        font_system: &'a FontSystem,
         line: &str,
         attrs_list: &AttrsList,
         start_span: usize,
@@ -424,7 +424,7 @@ pub struct ShapeLine {
 
 impl ShapeLine {
     pub fn new<'a>(
-        font_system: &'a FontSystem<'a>,
+        font_system: &'a FontSystem,
         line: &str,
         attrs_list: &AttrsList
     ) -> Self {

--- a/src/swash.rs
+++ b/src/swash.rs
@@ -9,7 +9,7 @@ use crate::{CacheKey, Color, FontSystem};
 
 pub use swash::scale::image::{Content as SwashContent, Image as SwashImage};
 
-fn swash_image<'a>(font_system: &'a FontSystem<'a>, context: &mut ScaleContext, cache_key: CacheKey) -> Option<SwashImage> {
+fn swash_image<'a>(font_system: &'a FontSystem, context: &mut ScaleContext, cache_key: CacheKey) -> Option<SwashImage> {
     let font = match font_system.get_font(cache_key.font_id) {
         Some(some) => some,
         None => {
@@ -49,14 +49,14 @@ fn swash_image<'a>(font_system: &'a FontSystem<'a>, context: &mut ScaleContext, 
 
 /// Cache for rasterizing with the swash scaler
 pub struct SwashCache<'a> {
-    font_system: &'a FontSystem<'a>,
+    font_system: &'a FontSystem,
     context: ScaleContext,
     pub image_cache: HashMap<CacheKey, Option<SwashImage>>,
 }
 
 impl<'a> SwashCache<'a> {
     /// Create a new swash cache
-    pub fn new(font_system: &'a FontSystem<'a>) -> Self {
+    pub fn new(font_system: &'a FontSystem) -> Self {
         Self {
             font_system: font_system,
             context: ScaleContext::new(),


### PR DESCRIPTION
Perhaps not quite what ouroboros is expected to be used for, but it's not too bad, and avoiding the lifetime bound can be a huge help.

The remaining issue here is the lifetime bound for `Attrs`.