### PR TITLE
bugfix: text selection starting from the bottom

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -477,6 +477,16 @@ impl<'a> Buffer<'a> {
                 break;
             }
         }
+        // Fixes text selection if the user starts dragging from below the last line.
+        if let Some(run) = self.layout_runs().last() {
+            if y > run.line_y {
+                let mut new_cursor = Cursor::new(run.line_i, 0);
+                if let Some(glyph) = run.glyphs.last() {
+                    new_cursor.index = glyph.end;
+                }
+                new_cursor_opt = Some(new_cursor);
+            }
+        }
 
         let duration = instant.elapsed();
         log::trace!("click({}, {}): {:?}", x, y, duration);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -416,7 +416,8 @@ impl<'a> Buffer<'a> {
 
         let mut new_cursor_opt = None;
 
-        for run in self.layout_runs() {
+        let mut runs = self.layout_runs().peekable();
+        while let Some(run) = runs.next() {
             let line_y = run.line_y;
 
             if y >= line_y - font_size
@@ -475,11 +476,7 @@ impl<'a> Buffer<'a> {
                 new_cursor_opt = Some(new_cursor);
 
                 break;
-            }
-        }
-        // Fixes text selection if the user starts dragging from below the last line.
-        if let Some(run) = self.layout_runs().last() {
-            if y > run.line_y {
+            } else if runs.peek().is_none() && y > run.line_y {
                 let mut new_cursor = Cursor::new(run.line_i, 0);
                 if let Some(glyph) = run.glyphs.last() {
                     new_cursor.index = glyph.end;


### PR DESCRIPTION
This fixes a bug in the text selection.
Steps to reproduce the bug:
- Have a paragraph of text.
- Select a portion of that text.
- Then try dragging from below the last line (where there is no text)
- The selected text instead of starting from the bottom, starts from the end of previous selection to the current mouse position.

