### PR TITLE
🍮 Add custom font support

### DIFF
--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -29,8 +29,6 @@ impl<'a> Font<'a> {
             }
             #[cfg(feature = "std")]
             fontdb::Source::SharedFile(_path, data) => data.deref().as_ref(),
-            #[cfg(not(feature = "std"))]
-            _ => { todo!(""); }
         };
 
         Some(Self {

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -29,6 +29,8 @@ impl<'a> Font<'a> {
             }
             #[cfg(feature = "std")]
             fontdb::Source::SharedFile(_path, data) => data.deref().as_ref(),
+            #[cfg(not(feature = "std"))]
+            _ => { todo!(""); }
         };
 
         Some(Self {

--- a/src/font/system/no_std.rs
+++ b/src/font/system/no_std.rs
@@ -16,13 +16,10 @@ pub struct FontSystem{
 
 impl FontSystem {
     pub fn new() -> Self {
-        //TODO: get locale from argument?
         let locale = "en-US".to_string();
 
-        //TODO: allow loading fonts from memory
         let mut db = fontdb::Database::new();
         {
-            //TODO: configurable default fonts
             db.set_monospace_family("Fira Mono");
             db.set_sans_serif_family("Fira Sans");
             db.set_serif_family("DejaVu Serif");
@@ -31,6 +28,13 @@ impl FontSystem {
         Self {
             locale,
             db,
+        }
+    }
+
+    pub fn new_with_locale_and_db(locale: &str, db: fontdb::Database) -> Self {
+        Self {
+            locale: locale.to_string(),
+            db
         }
     }
 


### PR DESCRIPTION
This addresses (at least in the `no_std` case, I can amend the `std` case as well) the todo's that were left about being able to load custom fonts. We needed this for our use-case since we can't rely on OS fonts in our case.