### PR TITLE
Use the `fontdb` matching algorithm instead of a custom one

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -156,7 +156,6 @@ impl<'a> Attrs<'a> {
 
     /// Check if font matches
     pub fn matches(&self, face: &fontdb::FaceInfo) -> bool {
-        //TODO: smarter way of including emoji
         face.post_script_name.contains("Emoji") ||
         (
             face.style == self.style &&

--- a/src/font/system/no_std.rs
+++ b/src/font/system/no_std.rs
@@ -61,15 +61,24 @@ impl FontSystem {
 
     pub fn get_font_matches<'a>(&'a self, attrs: Attrs) -> Arc<FontMatches<'a>> {
         let mut fonts = Vec::new();
-        for face in self.db.faces() {
-            if !attrs.matches(face) {
-                continue;
-            }
+        // for face in self.db.faces() {
+        //     log::info!("{:?}", face.family);
+        //     if !attrs.matches(face) {
+        //         continue;
+        //     }
 
-            if let Some(font) = self.get_font(face.id) {
-                fonts.push(font);
+        //     if let Some(font) = self.get_font(face.id) {
+        //         fonts.push(font);
+        //     }
+        // }
+
+        fonts.push(self.get_font(self.db.query(
+            &fontdb::Query {
+                families: &[fontdb::Family::SansSerif],
+                weight: attrs.weight,
+                ..fontdb::Query::default()
             }
-        }
+         ).unwrap() ).unwrap());
 
         Arc::new(FontMatches {
             locale: &self.locale,


### PR DESCRIPTION
This code is quite WIP and shouldn't be merged in as-is.

Having said that, I would like to know what people's thoughts are around this. Currently it appears that `cosmic-text` is trying to find an exact match to the font that's currently required.

On the other hand, fontdb implements the CSS font-matching algorithm which seems to lead to better results for us when doing more fuzzy matching. (For example; searching for a bold font but not finding one of the exact weight will find one with the closes weight, etc).

If that's a way to go, I'd love to polish up this PR.