### PR TITLE
Fix bidi layout

### DIFF
--- a/sample/farsi.txt
+++ b/sample/farsi.txt
@@ -7,4 +7,5 @@
 ویرگول (؛).
 تای تأنیث یا ه دو نقطه (ة).
 علامت تشدید (ــّـ).
-
+Testing LEFT‑TO‑RIGHT ISOLATE (U+2066) and POP DIRECTIONAL ISOLATE (U+2069):
+He said: "بهتره از  ⁦Rust⁩ استفاده کنی".

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -225,7 +225,7 @@ impl<'a> Edit<'a> for SyntaxEditor<'a> {
 
             // Update line attributes. This operation only resets if the line changes
             line.set_attrs_list(attrs_list);
-            line.set_wrap_simple(true);
+            line.set_wrap_simple(false);
 
             //TODO: efficiently do syntax highlighting without having to shape whole buffer
             buffer.line_shape(line_i);
@@ -246,7 +246,7 @@ impl<'a> Edit<'a> for SyntaxEditor<'a> {
         if highlighted > 0 {
             buffer.set_redraw(true);
             #[cfg(feature = "std")]
-            log::debug!("Syntax highlighted {} lines in {:?}", highlighted, now.elapsed());
+            log::debug!("Syntax highlighted {} lines in {:?}", highlighted, now.elapsed()); 
         }
 
         self.editor.shape_as_needed();

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -420,8 +420,6 @@ impl ShapeSpan {
 pub struct ShapeLine {
     pub rtl: bool,
     pub spans: Vec<ShapeSpan>,
-    pub levels: Vec<Level>,
-    pub runs: Vec<Range<usize>>,
 }
 
 impl ShapeLine {
@@ -431,8 +429,6 @@ impl ShapeLine {
         attrs_list: &AttrsList
     ) -> Self {
         let mut spans = Vec::new();
-        let levels = Vec::new();
-        let runs = Vec::new();
 
         let bidi = unicode_bidi::BidiInfo::new(line, None);
         let rtl = if bidi.paragraphs.is_empty() {
@@ -449,7 +445,7 @@ impl ShapeLine {
 
             if line_rtl {
                 for range in runs.into_iter().rev() {
-                    let span_rtl = levels[range.start].is_rtl(); //paragraph.info.levels[i].is_rtl();
+                    let span_rtl = levels[range.start].is_rtl(); 
                     spans.push(ShapeSpan::new(
                         font_system,
                         line,
@@ -480,7 +476,7 @@ impl ShapeLine {
             line_rtl
         };
 
-        Self { rtl, spans, levels, runs }
+        Self { rtl, spans}
     }
 
     pub fn layout(


### PR DESCRIPTION
This closes #37 .

Current implementation of Cosmic-text uses a simple method which doesn't support embedded bidirectional text and especially Arabic numbers.

This PR uses the [BiDi algorithm](http://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels) (implemented in [unicode_bidi](https://docs.rs/unicode-bidi/latest/unicode_bidi/) ). 