### PR TITLE
Add line width field to `LayoutLine`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -55,6 +55,8 @@ pub struct LayoutRun<'a> {
     pub glyphs: &'a [LayoutGlyph],
     /// Y offset of line
     pub line_y: i32,
+    /// width of line
+    pub line_w: f32,
 }
 
 /// An iterator of visible text lines, see [`LayoutRun`]
@@ -105,6 +107,7 @@ impl<'a, 'b> Iterator for LayoutRunIter<'a, 'b> {
                     rtl: shape.rtl,
                     glyphs: &layout_line.glyphs,
                     line_y: self.line_y,
+                    line_w: layout_line.w,
                 });
             }
             self.line_i += 1;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -32,6 +32,8 @@ pub struct LayoutGlyph {
 
 /// A line of laid out glyphs
 pub struct LayoutLine {
+    /// Width of the line
+    pub w: f32,
     /// Glyphs in line
     pub glyphs: Vec<LayoutGlyph>,
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -594,6 +594,7 @@ impl ShapeLine {
                         mem::swap(&mut glyphs, &mut glyphs_swap);
                         layout_lines.push(
                             LayoutLine {
+                                w: x,
                                 glyphs: glyphs_swap,
                             },
                         );
@@ -623,6 +624,7 @@ impl ShapeLine {
                             mem::swap(&mut glyphs, &mut glyphs_swap);
                             layout_lines.push(
                                 LayoutLine {
+                                    w: x,
                                     glyphs: glyphs_swap,
                                 },
                             );
@@ -650,6 +652,7 @@ impl ShapeLine {
                     mem::swap(&mut glyphs, &mut glyphs_swap);
                     layout_lines.push(
                         LayoutLine {
+                            w: x,
                             glyphs: glyphs_swap,
                         },
                     );
@@ -663,6 +666,7 @@ impl ShapeLine {
         if push_line {
             layout_lines.push(
                 LayoutLine {
+                    w: x,
                     glyphs,
                 },
             );


### PR DESCRIPTION
Added a `w` field to `LayoutLine` and a `line_w` to `LayoutRun`.

These are useful to avoid iterating through all the glyphs just to figure out the line width (e.g. for alignment purposes).