### PR TITLE
Expose subpixel offsets in `LayoutGlyph`

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -20,6 +20,10 @@ pub struct LayoutGlyph {
     pub rtl: bool,
     /// Cache key, see [CacheKey]
     pub cache_key: CacheKey,
+    // X offset in line
+    pub x_offset: f32,
+    // Y offset in line
+    pub y_offset: f32,
     /// Integer component of X offset in line
     pub x_int: i32,
     /// Integer component of Y offset in line

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -22,7 +22,7 @@ pub struct LayoutGlyph {
     pub cache_key: CacheKey,
     /// X offset in line
     ///
-    /// Unless you are not dealing with physical coordinates, you will want to use [`Self::x_int`]
+    /// If you are dealing with physical coordinates, you will want to use [`Self::x_int`]
     /// together with [`CacheKey::x_bin`] instead. This will ensure the best alignment of the
     /// rasterized glyphs with the pixel grid.
     ///
@@ -32,7 +32,7 @@ pub struct LayoutGlyph {
     pub x_offset: f32,
     /// Y offset in line
     ///
-    /// Unless you are not dealing with physical coordinates, you will want to use [`Self::y_int`]
+    /// If you are dealing with physical coordinates, you will want to use [`Self::y_int`]
     /// together with [`CacheKey::y_bin`] instead. This will ensure the best alignment of the
     /// rasterized glyphs with the pixel grid.
     ///

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -20,9 +20,25 @@ pub struct LayoutGlyph {
     pub rtl: bool,
     /// Cache key, see [CacheKey]
     pub cache_key: CacheKey,
-    // X offset in line
+    /// X offset in line
+    ///
+    /// Unless you are not dealing with physical coordinates, you will want to use [`Self::x_int`]
+    /// together with [`CacheKey::x_bin`] instead. This will ensure the best alignment of the
+    /// rasterized glyphs with the pixel grid.
+    ///
+    /// This offset is useful when you are dealing with logical units and you do not care or
+    /// cannot guarantee pixel grid alignment. For instance, when you want to use the glyphs
+    /// for vectorial text, apply linear transformations to the layout, etc.
     pub x_offset: f32,
-    // Y offset in line
+    /// Y offset in line
+    ///
+    /// Unless you are not dealing with physical coordinates, you will want to use [`Self::y_int`]
+    /// together with [`CacheKey::y_bin`] instead. This will ensure the best alignment of the
+    /// rasterized glyphs with the pixel grid.
+    ///
+    /// This offset is useful when you are dealing with logical units and you do not care or
+    /// cannot guarantee pixel grid alignment. For instance, when you want to use the glyphs
+    /// for vectorial text, apply linear transformations to the layout, etc.
     pub y_offset: f32,
     /// Integer component of X offset in line
     pub x_int: i32,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -262,6 +262,8 @@ impl ShapeGlyph {
             w: x_advance,
             rtl,
             cache_key,
+            x_offset,
+            y_offset,
             x_int,
             y_int,
             color_opt: self.color_opt,


### PR DESCRIPTION
This PR exposes the `x_offset` and `y_offset` of a `LayoutGlyph` instead of just the integer components.

I believe these are necessary to properly position glyphs when dealing with logical units instead of physical ones (e.g. when rendering outlines #51).