### PR TITLE
Bidi reordering and wrapping

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -482,7 +482,7 @@ impl<'a> Buffer<'a> {
                                 new_cursor_char = egc_i;
 
                                 let right_half = x >= (egc_x + egc_w / 2.0) as i32;
-                                if right_half != glyph.rtl {
+                                if right_half != glyph.level.is_rtl() {
                                     // If clicking on last half of glyph, move cursor past glyph
                                     new_cursor_char += egc.len();
                                 }
@@ -492,7 +492,7 @@ impl<'a> Buffer<'a> {
                         }
 
                         let right_half = x >= (glyph.x + glyph.w / 2.0) as i32;
-                        if right_half != glyph.rtl {
+                        if right_half != glyph.level.is_rtl() {
                             // If clicking on last half of glyph, move cursor past glyph
                             new_cursor_char = cluster.len();
                         }

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -630,7 +630,7 @@ impl<'a> Edit<'a> for Editor<'a> {
                 let x = match run.glyphs.get(cursor_glyph) {
                     Some(glyph) => {
                         // Start of detected glyph
-                        if glyph.rtl {
+                        if glyph.level.is_rtl() {
                             (glyph.x + glyph.w - cursor_glyph_offset) as i32
                         } else {
                             (glyph.x + cursor_glyph_offset) as i32
@@ -639,7 +639,7 @@ impl<'a> Edit<'a> for Editor<'a> {
                     None => match run.glyphs.last() {
                         Some(glyph) => {
                             // End of last glyph
-                            if glyph.rtl {
+                            if glyph.level.is_rtl() {
                                 glyph.x as i32
                             } else {
                                 (glyph.x + glyph.w) as i32

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -358,7 +358,7 @@ impl<'a> Edit<'a> for ViEditor<'a> {
                 let (start_x, end_x) = match run.glyphs.get(cursor_glyph) {
                     Some(glyph) => {
                         // Start of detected glyph
-                        if glyph.rtl {
+                        if glyph.level.is_rtl() {
                             (
                                 (glyph.x + glyph.w - cursor_glyph_offset) as i32,
                                 (glyph.x + glyph.w - cursor_glyph_offset - cursor_glyph_width) as i32,
@@ -373,7 +373,7 @@ impl<'a> Edit<'a> for ViEditor<'a> {
                     None => match run.glyphs.last() {
                         Some(glyph) => {
                             // End of last glyph
-                            if glyph.rtl {
+                            if glyph.level.is_rtl() {
                                 (
                                     glyph.x as i32,
                                     (glyph.x - cursor_glyph_width) as i32

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -17,7 +17,7 @@ pub struct LayoutGlyph {
     /// width of hitbox
     pub w: f32,
     /// True if the character is from an RTL script
-    pub rtl: bool,
+    pub level: unicode_bidi::Level,
     /// Cache key, see [CacheKey]
     pub cache_key: CacheKey,
     /// X offset in line

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -711,6 +711,10 @@ impl ShapeLine {
                             }
                             fitting_start = i;
                             fit_x = start_x;
+                            if i >= span.words.len() {
+                                break;
+                            }
+                            continue;
                         }
 
                         if self.rtl {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -498,10 +498,9 @@ impl ShapeLine {
 
         // Reset some whitespace chars to paragraph level.
         // <http://www.unicode.org/reports/tr9/#L1>
-        let line_str: &str = &text[..];
         let mut reset_from: Option<usize> = Some(0);
         let mut reset_to: Option<usize> = None;
-        for (i, c) in line_str.char_indices() {
+        for (i, c) in text.char_indices() {
             match line_classes[i] {
                 // Ignored by X9
                 RLE | LRE | RLO | LRO | PDF | BN => {}
@@ -509,13 +508,13 @@ impl ShapeLine {
                 B | S => {
                     assert_eq!(reset_to, None);
                     reset_to = Some(i + c.len_utf8());
-                    if reset_from == None {
+                    if reset_from.is_none() {
                         reset_from = Some(i);
                     }
                 }
                 // Whitespace, isolate formatting
                 WS | FSI | LRI | RLI | PDI => {
-                    if reset_from == None {
+                    if reset_from.is_none() {
                         reset_from = Some(i);
                     }
                 }
@@ -540,7 +539,7 @@ impl ShapeLine {
     }
 
     // A modified version of second part of unicode_bidi::bidi_info::visual run
-    fn reorder(&self, line_range: &Vec<(usize, Range<usize>)>) -> Vec<Range<usize>> {
+    fn reorder(&self, line_range: &[(usize, Range<usize>)]) -> Vec<Range<usize>> {
         let line : Vec<unicode_bidi::Level> = line_range.iter().map(|(span_index, _)| self.spans[*span_index].level).collect();
         // Find consecutive level runs.
         let mut runs = Vec::new();
@@ -744,13 +743,13 @@ impl ShapeLine {
             }
         }
 
-        if current_visual_line.len() > 0 {
+        if !current_visual_line.is_empty() {
             vl_range_of_spans.push(current_visual_line);
         }
 
 
         for visual_line in &vl_range_of_spans {
-            let new_order = self.reorder(&visual_line);
+            let new_order = self.reorder(visual_line);
             let mut glyphs = Vec::with_capacity(1);
             x = start_x;
             y = 0.;
@@ -807,7 +806,7 @@ impl ShapeLine {
         }
 
         if push_line {
-            layout_lines.push(LayoutLine { w: 0.0 , glyphs: vec![] });
+            layout_lines.push(LayoutLine { w: 0.0 , glyphs: Default::default() });
         }
 
         layout_lines

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -658,9 +658,8 @@ impl ShapeLine {
                                     break;
                                 }
                             }
-                        word_ranges.push((fitting_start..fitting_end, true));
+                            word_ranges.push((fitting_start..fitting_end, true));
                             fitting_end = i + 1;
-
                             fit_x = start_x;
                         }
 
@@ -701,15 +700,18 @@ impl ShapeLine {
                         };
 
                         if wrap {
-                                word_ranges.push((fitting_start..i, true));
-
-                                if word.blank {
+                            if fitting_start == i { // One word is bigger than the linewidth
+                                i += 1;
+                            }
+                            word_ranges.push((fitting_start..i, true));
+                            if let Some(next_word) = &span.words.get(i) {
+                                if next_word.blank {
                                     i += 1;
                                 }
-                                fitting_start = i;
-
-                                fit_x = start_x;
                             }
+                            fitting_start = i;
+                            fit_x = start_x;
+                        }
 
                         if self.rtl {
                             fit_x -= word_size;
@@ -723,7 +725,9 @@ impl ShapeLine {
                         }
                     }
                 }
-                word_ranges.push((fitting_start..span.words.len(), false));
+                if fitting_start < span.words.len() {
+                    word_ranges.push((fitting_start..span.words.len(), false));
+                }
             }
 
             // Calculate the actual size 
@@ -737,7 +741,6 @@ impl ShapeLine {
                     } else {
                         x + word_size > end_x
                     };
-                    
                     if word_wrap && !wrap_simple  {
                         current_visual_line.push((span_index, range.clone()));
                         vl_range_of_spans.push(current_visual_line);
@@ -768,7 +771,6 @@ impl ShapeLine {
         if !current_visual_line.is_empty() {
             vl_range_of_spans.push(current_visual_line);
         }
-
 
         for visual_line in &vl_range_of_spans {
             let new_order = self.reorder(visual_line);

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -633,35 +633,42 @@ impl ShapeLine {
             if self.rtl != span.level.is_rtl() {
                 let mut fit_x = x;
                 let mut fitting_end = span.words.len();
-                for i in (0..span.words.len()).rev() {
-                    let word = &span.words[i];
-                    let word_size = font_size as f32 * word.x_advance;
+                if !span.words.is_empty() {
+                    let mut i = span.words.len()-1;
+                    loop {
+                        let word = &span.words[i];
+                        let word_size = font_size as f32 * word.x_advance;
 
-                    let wrap = if self.rtl {
-                        fit_x - word_size < end_x
-                    } else {
-                        fit_x + word_size > end_x
-                    };
+                        let wrap = if self.rtl {
+                            fit_x - word_size < end_x
+                        } else {
+                            fit_x + word_size > end_x
+                        };
 
-                    if wrap {
-                        let mut fitting_start = i + 1;
-                        while fitting_start < fitting_end {
-                            if span.words[fitting_start].blank {
-                                fitting_start += 1;
-                            } else {
-                                break;
+                        if wrap {
+                            let mut fitting_start = i + 1;
+                            while fitting_start < fitting_end {
+                                if span.words[fitting_start].blank {
+                                    fitting_start += 1;
+                                } else {
+                                    break;
+                                }
                             }
-                        }
                         word_ranges.push((fitting_start..fitting_end, true));
-                        fitting_end = i + 1;
+                            fitting_end = i + 1;
 
-                        fit_x = start_x;
-                    }
+                            fit_x = start_x;
+                        }
 
-                    if self.rtl {
-                        fit_x -= word_size;
-                    } else {
-                        fit_x += word_size;
+                        if self.rtl {
+                            fit_x -= word_size;
+                        } else {
+                            fit_x += word_size;
+                        }
+                        if i == 0 {
+                            break;
+                        }
+                        i -= 1;
                     }
                 }
                 if !word_ranges.is_empty() {
@@ -677,28 +684,39 @@ impl ShapeLine {
             } else {
                 let mut fit_x = x;
                 let mut fitting_start = 0;
-                for i in 0..span.words.len() {
-                    let word = &span.words[i];
-                    let word_size = font_size as f32 * word.x_advance;
+                if !span.words.is_empty() {
+                    let mut i = 0;
+                    loop {
+                        let word = &span.words[i];
+                        let word_size = font_size as f32 * word.x_advance;
 
-                    let wrap = if self.rtl {
-                        fit_x - word_size < end_x
-                    } else {
-                        fit_x + word_size > end_x
-                    };
+                        let wrap = if self.rtl {
+                            fit_x - word_size < end_x
+                        } else {
+                            fit_x + word_size > end_x
+                        };
 
-                    if wrap {
-                        //TODO: skip blanks
-                        word_ranges.push((fitting_start..i, true));
-                        fitting_start = i;
+                        if wrap {
+                                word_ranges.push((fitting_start..i, true));
 
-                        fit_x = start_x;
-                    }
+                                if word.blank {
+                                    i += 1;
+                                }
+                                fitting_start = i;
 
-                    if self.rtl {
-                        fit_x -= word_size;
-                    } else {
-                        fit_x += word_size;
+                                fit_x = start_x;
+                            }
+
+                        if self.rtl {
+                            fit_x -= word_size;
+                        } else {
+                            fit_x += word_size;
+                        }
+
+                        i += 1;
+                        if i >= span.words.len() {
+                            break;
+                        }
                     }
                 }
                 word_ranges.push((fitting_start..span.words.len(), false));
@@ -715,7 +733,7 @@ impl ShapeLine {
                     } else {
                         x + word_size > end_x
                     };
-
+                    
                     if word_wrap && !wrap_simple  {
                         current_visual_line.push((span_index, range.clone()));
                         vl_range_of_spans.push(current_visual_line);

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -378,6 +378,7 @@ impl ShapeSpan {
                     break;
                 } else if c.is_whitespace() {
                     start_lb = start_word + i;
+                    break;
                 }
             }
             if start_word < start_lb {
@@ -391,14 +392,17 @@ impl ShapeSpan {
                 ));
             }
             if start_lb < end_lb {
-                words.push(ShapeWord::new(
-                    font_system,
-                    line,
-                    attrs_list,
-                    (span_range.start + start_lb)..(span_range.start + end_lb),
-                    level,
-                    true,
-                ));
+                for (i, c) in span[start_lb..end_lb].char_indices() {
+                    // assert!(c.is_whitespace());
+                    words.push(ShapeWord::new(
+                        font_system,
+                        line,
+                        attrs_list,
+                        (span_range.start + start_lb + i)..(span_range.start + start_lb + i + c.len_utf8()),
+                        level,
+                        true,
+                    ));
+                }
             }
             start_word = end_lb;
         }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -278,8 +278,8 @@ impl ShapeGlyph {
 pub struct ShapeWord {
     pub blank: bool,
     pub glyphs: Vec<ShapeGlyph>,
-    x_advance: f32,
-    y_advance: f32,
+    pub x_advance: f32,
+    pub y_advance: f32,
 }
 
 impl ShapeWord {


### PR DESCRIPTION
Previously we were calling `unicode_bidi::bidi_info::visual_run` to reorder the embedded bidi text. This was working well for texts on one line, but wrapping text would break the algorithm.

I had to move the reordering algorithm into `cosmic_text` to be able to adapt it. Also I had to change the `ShapeLine::layout` function to create the `LayoutLine` at the end, after reordering.

Currently I can not do `wrap_simple` because I am using a `Vec<span_index, word_range>` to represent a line. But to be able to do `wrap_simple` I need to know where in a word the line break happens.

More detail: 
So with this PR, if we have a big chunk of LTR text that needs multiple visual lines. It would become one single `Span` with index `0` and the visual lines would be `[ [(0, 0..15)], [(0, 15..34)], ..]` (which is a `Vec<Vec<usize, Range>>`). Now if we have two small chunks of text, one 5 words LTR, one 4 words RTL and it would fit on one line. It would generate two Spans (indices `0`,`1`) and the Visual line would be `[[(0, 0..5), (1, 0..4)]]`. 

TODO:
- [x] Correct BiDi ordering per visual line
- [x] wrap_simple
- [x] Skip first space on a new line
- [x] A long sequence of whitespaces is considered a word and causes issues with wrapping
- [x] Words longer than the `line_width` break the layout (in the main branch too).