### PR TITLE
Downgrade some logging messages

### DIFF
--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -59,7 +59,7 @@ impl<'a> FontFallbackIter<'a> {
 
     pub fn check_missing(&self, word: &str) {
         if self.end {
-            log::warn!(
+            log::debug!(
                 "Failed to find any fallback for {:?} locale '{}': '{}'",
                 self.scripts,
                 self.locale,
@@ -67,7 +67,7 @@ impl<'a> FontFallbackIter<'a> {
             );
         } else if self.other_i > 0 {
             let font = &self.fonts[self.other_i - 1];
-            log::warn!(
+            log::debug!(
                 "Failed to find preset fallback for {:?} locale '{}', used '{}': '{}'",
                 self.scripts,
                 self.locale,
@@ -113,7 +113,7 @@ impl<'a> Iterator for FontFallbackIter<'a> {
                         return Some(font);
                     }
                 }
-                log::warn!(
+                log::debug!(
                     "failed to find family '{}' for script {:?} and locale '{}'",
                     script_family,
                     script,
@@ -134,7 +134,7 @@ impl<'a> Iterator for FontFallbackIter<'a> {
                     return Some(font);
                 }
             }
-            log::warn!("failed to find family '{}'", common_family);
+            log::debug!("failed to find family '{}'", common_family);
         }
 
         //TODO: do we need to do this?

--- a/src/font/system/redox.rs
+++ b/src/font/system/redox.rs
@@ -20,7 +20,7 @@ impl FontSystem {
             log::warn!("failed to get system locale, falling back to en-US");
             String::from("en-US")
         });
-        log::info!("Locale: {}", locale);
+        log::debug!("Locale: {}", locale);
 
         //TODO: allow loading fonts from memory
         let mut db = fontdb::Database::new();

--- a/src/font/system/std.rs
+++ b/src/font/system/std.rs
@@ -29,7 +29,7 @@ impl FontSystem {
             log::warn!("failed to get system locale, falling back to en-US");
             String::from("en-US")
         });
-        log::info!("Locale: {}", locale);
+        log::debug!("Locale: {}", locale);
 
         let mut db = fontdb::Database::new();
         {


### PR DESCRIPTION
Since integrating cosmic-text into Vizia, we've had some complaints from users about excessive log emissions. I went through all the non-example files and downgraded several logging messages that I thought users wouldn't need to see in a default configuration where they're seeing Info logs from all dependencies. I'm open to changing those levels further, though I would prefer the fallback logging stay at Debug because it is triggered every time any text is shaped, which can be quite often.