### PR TITLE
Don't do profile timing on wasm32

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -319,7 +319,7 @@ impl<'a> Buffer<'a> {
     }
 
     fn relayout(&mut self) {
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         let instant = std::time::Instant::now();
 
         for line in &mut self.lines {
@@ -336,13 +336,13 @@ impl<'a> Buffer<'a> {
 
         self.redraw = true;
 
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         log::debug!("relayout: {:?}", instant.elapsed());
     }
 
     /// Pre-shape lines in the buffer, up to `lines`, return actual number of layout lines
     pub fn shape_until(&mut self, lines: i32) -> i32 {
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         let instant = std::time::Instant::now();
 
         let mut reshaped = 0;
@@ -365,7 +365,7 @@ impl<'a> Buffer<'a> {
         }
 
         if reshaped > 0 {
-            #[cfg(feature = "std")]
+            #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
             log::debug!("shape_until {}: {:?}", reshaped, instant.elapsed());
             self.redraw = true;
         }
@@ -375,7 +375,7 @@ impl<'a> Buffer<'a> {
 
     /// Shape lines until cursor, also scrolling to include cursor in view
     pub fn shape_until_cursor(&mut self, cursor: Cursor) {
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         let instant = std::time::Instant::now();
 
         let mut reshaped = 0;
@@ -404,7 +404,7 @@ impl<'a> Buffer<'a> {
         }
 
         if reshaped > 0 {
-            #[cfg(feature = "std")]
+            #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
             log::debug!("shape_until_cursor {}: {:?}", reshaped, instant.elapsed());
             self.redraw = true;
         }
@@ -577,7 +577,7 @@ impl<'a> Buffer<'a> {
 
     /// Convert x, y position to Cursor (hit detection)
     pub fn hit(&self, x: i32, y: i32) -> Option<Cursor> {
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         let instant = std::time::Instant::now();
 
         let font_size = self.metrics.font_size;
@@ -670,7 +670,7 @@ impl<'a> Buffer<'a> {
             }
         }
 
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         log::trace!("click({}, {}): {:?}", x, y, instant.elapsed());
 
         new_cursor_opt

--- a/src/font/system/std.rs
+++ b/src/font/system/std.rs
@@ -33,6 +33,7 @@ impl FontSystem {
 
         let mut db = fontdb::Database::new();
         {
+            #[cfg(not(target_arch = "wasm32"))]
             let now = std::time::Instant::now();
 
             db.load_system_fonts();
@@ -41,6 +42,7 @@ impl FontSystem {
             db.set_sans_serif_family("Fira Sans");
             db.set_serif_family("DejaVu Serif");
 
+            #[cfg(not(target_arch = "wasm32"))]
             log::info!(
                 "Parsed {} font faces in {}ms.",
                 db.len(),
@@ -54,6 +56,7 @@ impl FontSystem {
     /// Create a new [`FontSystem`], manually specifying the current locale and font database.
     pub fn new_with_locale_and_db(locale: String, mut db: fontdb::Database) -> Self {
         {
+            #[cfg(not(target_arch = "wasm32"))]
             let now = std::time::Instant::now();
 
             //TODO only do this on demand!
@@ -64,6 +67,7 @@ impl FontSystem {
                 }
             }
 
+            #[cfg(not(target_arch = "wasm32"))]
             log::info!(
                 "Mapped {} font faces in {}ms.",
                 db.len(),
@@ -111,6 +115,7 @@ impl FontSystem {
             font_matches_cache
                 .entry(AttrsOwned::new(attrs))
                 .or_insert_with(|| {
+                    #[cfg(not(target_arch = "wasm32"))]
                     let now = std::time::Instant::now();
 
                     let mut fonts = Vec::new();
@@ -130,8 +135,11 @@ impl FontSystem {
                         fonts,
                     });
 
-                    let elapsed = now.elapsed();
-                    log::debug!("font matches for {:?} in {:?}", attrs, elapsed);
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        let elapsed = now.elapsed();
+                        log::debug!("font matches for {:?} in {:?}", attrs, elapsed);
+                    }
 
                     font_matches
                 })


### PR DESCRIPTION
wasm32-unknown-unknown, despite being a std target, will panic if you try to use the timing functions. There are crates that work around this, but for now the simplest solution is to just disable the timing mechanisms on this arch.