### PR TITLE
Fix `Noto Color Emoji` font fallback order for Unix

### DIFF
--- a/src/font/fallback/unix.rs
+++ b/src/font/fallback/unix.rs
@@ -8,8 +8,6 @@ pub fn common_fallback() -> &'static [&'static str] {
     &[
         /* Sans-serif fallbacks */
         "Noto Sans",
-        /* Emoji fallbacks*/
-        "Noto Color Emoji",
         /* More sans-serif fallbacks */
         "DejaVu Sans",
         "FreeSans",
@@ -20,6 +18,8 @@ pub fn common_fallback() -> &'static [&'static str] {
         /* Symbols fallbacks */
         "Noto Sans Symbols",
         "Noto Sans Symbols2",
+        /* Emoji fallbacks*/
+        "Noto Color Emoji",
         //TODO: Add CJK script here for doublewides?
     ]
 }


### PR DESCRIPTION
In my environment, the current fallback ordering is causing `cosmic-text` to choose a bunch of emoji for characters like `0` or even just space, instead of using DejaVu Sans. The changes here fix it.