### PR TITLE
bugfix: Panic if a line height of zero is passed into Buffer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -306,6 +306,8 @@ pub struct Buffer<'a> {
 impl<'a> Buffer<'a> {
     /// Create a new [`Buffer`] with the provided [`FontSystem`] and [`Metrics`]
     pub fn new(font_system: &'a FontSystem, metrics: Metrics) -> Self {
+        assert_ne!(metrics.line_height, 0, "line height cannot be 0");
+
         let mut buffer = Self {
             font_system,
             lines: Vec::new(),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -493,6 +493,7 @@ impl<'a> Buffer<'a> {
     /// Set the current [`Metrics`]
     pub fn set_metrics(&mut self, metrics: Metrics) {
         if metrics != self.metrics {
+            assert_ne!(metrics.font_size, 0, "font size cannot be 0");
             self.metrics = metrics;
             self.relayout();
             self.shape_until_scroll();


### PR DESCRIPTION
Ran into this panic and it took me a while to figure out what caused it. This PR makes it so, if a line height of zero is passed into `Buffer::new`, it panics. This is opposed to the divide by zero error that happens if it doesn't panic here.