### PR TITLE
Expose `Placement` from `zeno` in `swash` module

### DIFF
--- a/src/swash.rs
+++ b/src/swash.rs
@@ -13,7 +13,7 @@ use swash::zeno::{Format, Vector};
 use crate::{CacheKey, Color, FontSystem};
 
 pub use swash::scale::image::{Content as SwashContent, Image as SwashImage};
-pub use swash::zeno::Command;
+pub use swash::zeno::{Command, Placement};
 
 fn swash_image(
     font_system: &FontSystem,


### PR DESCRIPTION
Noticed this type is a part of `SwashImage` but isn't really re-exported. I needed it to build a basic glyph cache for software rendering purposes.