### PR TITLE
Move fields from `Buffer` into a `BufferData` struct

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,7 +5,10 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{cmp, fmt};
+use core::{
+    cmp, fmt,
+    ops::{Deref, DerefMut},
+};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[cfg(feature = "swash")]
@@ -295,9 +298,8 @@ impl fmt::Display for Metrics {
     }
 }
 
-/// A buffer of text that is shaped and laid out
-pub struct Buffer<'a> {
-    font_system: &'a FontSystem,
+/// Buffer data for a text that is shaped and laid out
+pub struct BufferData {
     /// [BufferLine]s (or paragraphs) of text in the buffer
     pub lines: Vec<BufferLine>,
     metrics: Metrics,
@@ -309,6 +311,14 @@ pub struct Buffer<'a> {
     wrap: Wrap,
 }
 
+/// A buffer of text that is shaped and laid out
+///
+/// See [`BufferData`] for publicly accessible fields
+pub struct Buffer<'a> {
+    font_system: &'a FontSystem,
+    data: BufferData,
+}
+
 impl<'a> Buffer<'a> {
     /// Create a new [`Buffer`] with the provided [`FontSystem`] and [`Metrics`]
     ///
@@ -318,8 +328,7 @@ impl<'a> Buffer<'a> {
     pub fn new(font_system: &'a FontSystem, metrics: Metrics) -> Self {
         assert_ne!(metrics.line_height, 0.0, "line height cannot be 0");
 
-        let mut buffer = Self {
-            font_system,
+        let data = BufferData {
             lines: Vec::new(),
             metrics,
             width: 0.0,
@@ -328,22 +337,31 @@ impl<'a> Buffer<'a> {
             redraw: false,
             wrap: Wrap::Word,
         };
+        let mut buffer = Self { font_system, data };
         buffer.set_text("", Attrs::new());
         buffer
+    }
+
+    pub fn from_data(font_system: &'a FontSystem, data: BufferData) -> Self {
+        Self { font_system, data }
+    }
+
+    pub fn into_data(self) -> BufferData {
+        self.data
     }
 
     fn relayout(&mut self) {
         #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         let instant = std::time::Instant::now();
 
-        for line in &mut self.lines {
+        for line in &mut self.data.lines {
             if line.shape_opt().is_some() {
                 line.reset_layout();
                 line.layout(
                     self.font_system,
-                    self.metrics.font_size,
-                    self.width,
-                    self.wrap,
+                    self.data.metrics.font_size,
+                    self.data.width,
+                    self.data.wrap,
                 );
             }
         }
@@ -361,7 +379,7 @@ impl<'a> Buffer<'a> {
 
         let mut reshaped = 0;
         let mut total_layout = 0;
-        for line in &mut self.lines {
+        for line in &mut self.data.lines {
             if total_layout >= lines {
                 break;
             }
@@ -371,9 +389,9 @@ impl<'a> Buffer<'a> {
             }
             let layout = line.layout(
                 self.font_system,
-                self.metrics.font_size,
-                self.width,
-                self.wrap,
+                self.data.metrics.font_size,
+                self.data.width,
+                self.data.wrap,
             );
             total_layout += layout.len() as i32;
         }
@@ -394,7 +412,7 @@ impl<'a> Buffer<'a> {
 
         let mut reshaped = 0;
         let mut layout_i = 0;
-        for (line_i, line) in self.lines.iter_mut().enumerate() {
+        for (line_i, line) in self.data.lines.iter_mut().enumerate() {
             if line_i > cursor.line {
                 break;
             }
@@ -404,9 +422,9 @@ impl<'a> Buffer<'a> {
             }
             let layout = line.layout(
                 self.font_system,
-                self.metrics.font_size,
-                self.width,
-                self.wrap,
+                self.data.metrics.font_size,
+                self.data.width,
+                self.data.wrap,
             );
             if line_i == cursor.line {
                 let layout_cursor = self.layout_cursor(&cursor);
@@ -480,18 +498,18 @@ impl<'a> Buffer<'a> {
 
     /// Shape the provided line index and return the result
     pub fn line_shape(&mut self, line_i: usize) -> Option<&ShapeLine> {
-        let line = self.lines.get_mut(line_i)?;
+        let line = self.data.lines.get_mut(line_i)?;
         Some(line.shape(self.font_system))
     }
 
     /// Lay out the provided line index and return the result
     pub fn line_layout(&mut self, line_i: usize) -> Option<&[LayoutLine]> {
-        let line = self.lines.get_mut(line_i)?;
+        let line = self.data.lines.get_mut(line_i)?;
         Some(line.layout(
             self.font_system,
-            self.metrics.font_size,
-            self.width,
-            self.wrap,
+            self.data.metrics.font_size,
+            self.data.width,
+            self.data.wrap,
         ))
     }
 
@@ -718,5 +736,19 @@ impl<'a> Buffer<'a> {
                 });
             }
         }
+    }
+}
+
+impl<'a> Deref for Buffer<'a> {
+    type Target = BufferData;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<'a> DerefMut for Buffer<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
     }
 }


### PR DESCRIPTION
As noted by others in #39, keeping `Buffer`s around is cumbersome because it borrows `FontSystem`. This PR tries to solve that by making `Buffer` a wrapper around a new `BufferData` struct that contains all data previously owned by `Buffer`. 

`Buffer::from_data` and `Buffer::into_data` allow converting between `Buffer` and `BufferData`. 

Users of `Buffer` shouldn't need to change anything, because `Buffer` references are coerced to `BufferData` references via `Deref`/`DerefMut`.

Note: This is only a first step towards better ergonomics, because moving `BufferData` into `Buffer` can be itself pretty cumbersome and may require suboptimal code like using `Option<BufferData>`.
I envision the following steps for a follow-up:
1. Make `Buffer` borrow `BufferData` instead of owning it. The idea is that users would always store `BufferData` instead of `Buffer` and create a temporary `Buffer` when they need to work with it.
2. (Optional) If it is desired to keep an owning `Buffer`, we could instead rename `Buffer` to `OwnedBuffer`, and add something like this:
```rust
pub struct Buffer<'a> {
    font_system: &'a FontSystem,
    data: &'a mut BufferData,
}

pub trait BufferMethods {
    fn inner(&mut self) -> (&FontSystem, &mut BufferData);

    // Methods of the old Buffer would be moved here, with a default implementation 
    // that operates on the FontSystem and BufferData returned by inner
    ...
}

impl<'a> BufferMethods for Buffer<'a> {
    fn inner(&mut self) -> (&FontSystem, &mut BufferData) {
        (self.font_system, self.data)
    }
}  

impl<'a> BufferMethods for OwnedBuffer<'a> {
    fn inner(&mut self) -> (&FontSystem, &mut BufferData) {
        (self.font_system, &mut self.data)
    }
}
``` 