### PR TITLE
Remove lifetime from `SwashCache`

### DIFF
--- a/examples/editor-libcosmic/src/text.rs
+++ b/examples/editor-libcosmic/src/text.rs
@@ -14,6 +14,8 @@ use cosmic::{
 use cosmic_text::{Attrs, AttrsList, BufferLine, Metrics, SwashCache};
 use std::{cmp, sync::Mutex, time::Instant};
 
+use crate::FONT_SYSTEM;
+
 pub struct Appearance {
     background_color: Option<Color>,
     text_color: Color,
@@ -183,11 +185,16 @@ where
                     None => text_color,
                 };
 
-                cache.with_pixels(cache_key, glyph_color, |pixel_x, pixel_y, color| {
-                    let x = x_int + pixel_x;
-                    let y = line_y as i32 + y_int + pixel_y;
-                    draw_pixel(&mut pixels, layout_w as i32, layout_h as i32, x, y, color);
-                });
+                cache.with_pixels(
+                    &FONT_SYSTEM,
+                    cache_key,
+                    glyph_color,
+                    |pixel_x, pixel_y, color| {
+                        let x = x_int + pixel_x;
+                        let y = line_y as i32 + y_int + pixel_y;
+                        draw_pixel(&mut pixels, layout_w as i32, layout_h as i32, x, y, color);
+                    },
+                );
             }
             line_y += self.metrics.line_height;
         }
@@ -259,7 +266,7 @@ where
 }
 
 pub struct State {
-    cache: Mutex<SwashCache<'static>>,
+    cache: Mutex<SwashCache>,
 }
 
 impl State {
@@ -268,7 +275,7 @@ impl State {
         let instant = Instant::now();
 
         let state = State {
-            cache: Mutex::new(SwashCache::new(&crate::FONT_SYSTEM)),
+            cache: Mutex::new(SwashCache::new()),
         };
 
         log::debug!("created state in {:?}", instant.elapsed());

--- a/examples/editor-libcosmic/src/text_box.rs
+++ b/examples/editor-libcosmic/src/text_box.rs
@@ -348,7 +348,7 @@ where
 
 pub struct State {
     is_dragging: bool,
-    cache: Mutex<SwashCache<'static>>,
+    cache: Mutex<SwashCache>,
 }
 
 impl State {
@@ -356,7 +356,7 @@ impl State {
     pub fn new() -> State {
         State {
             is_dragging: false,
-            cache: Mutex::new(SwashCache::new(&crate::FONT_SYSTEM)),
+            cache: Mutex::new(SwashCache::new()),
         }
     }
 }

--- a/examples/editor-orbclient/src/main.rs
+++ b/examples/editor-orbclient/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
         }
     }
 
-    let mut swash_cache = SwashCache::new(&font_system);
+    let mut swash_cache = SwashCache::new();
 
     let mut ctrl_pressed = false;
     let mut mouse_x = -1;

--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
 
     let mut editor = Editor::new(buffer);
 
-    let mut swash_cache = SwashCache::new(&font_system);
+    let mut swash_cache = SwashCache::new();
 
     let text = if let Some(arg) = env::args().nth(1) {
         fs::read_to_string(&arg).expect("failed to open file")

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
             .push(BufferLine::new(line_text, attrs_list));
     }
 
-    let mut swash_cache = SwashCache::new(&font_system);
+    let mut swash_cache = SwashCache::new();
 
     //TODO: make window not async?
     let mut mouse_x = -1;

--- a/examples/terminal/src/main.rs
+++ b/examples/terminal/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     let font_system = FontSystem::new();
 
     // A SwashCache stores rasterized glyphs, create one per application
-    let mut swash_cache = SwashCache::new(&font_system);
+    let mut swash_cache = SwashCache::new();
 
     // Text metrics indicate the font size and line height of a buffer
     let metrics = Metrics::new(14.0, 20.0);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -705,7 +705,7 @@ impl<'a> Buffer<'a> {
                     None => color,
                 };
 
-                cache.with_pixels(cache_key, glyph_color, |x, y, color| {
+                cache.with_pixels(self.font_system, cache_key, glyph_color, |x, y, color| {
                     f(x_int + x, run.line_y as i32 + y_int + y, 1, 1, color);
                 });
             }

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -826,9 +826,14 @@ impl<'a> Edit<'a> for Editor<'a> {
                     None => color,
                 };
 
-                cache.with_pixels(cache_key, glyph_color, |x, y, color| {
-                    f(x_int + x, line_y as i32 + y_int + y, 1, 1, color);
-                });
+                cache.with_pixels(
+                    self.buffer.font_system(),
+                    cache_key,
+                    glyph_color,
+                    |x, y, color| {
+                        f(x_int + x, line_y as i32 + y_int + y, 1, 1, color);
+                    },
+                );
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! let font_system = FontSystem::new();
 //!
 //! // A SwashCache stores rasterized glyphs, create one per application
-//! let mut swash_cache = SwashCache::new(&font_system);
+//! let mut swash_cache = SwashCache::new();
 //!
 //! // Text metrics indicate the font size and line height of a buffer
 //! let metrics = Metrics::new(14.0, 20.0);


### PR DESCRIPTION
This removes the borrow of `FontSystem` from `SwashCache`, removing the need for a lifetime type parameter. Methods of `SwashCache` now take a `&FontSystem` instead, similar to #39. As the methods of `SwashCache` are few and, I believe,  will often not be used directly, the decrease in ergonomics should be tolerable.