### PR TITLE
docs: Add a warning about FontSystem::new()

### DIFF
--- a/src/font/system/std.rs
+++ b/src/font/system/std.rs
@@ -24,9 +24,9 @@ pub struct FontSystem(FontSystemInner);
 
 impl FontSystem {
     /// Create a new [`FontSystem`], that allows access to any installed system fonts
-    /// 
+    ///
     /// # Timing
-    /// 
+    ///
     /// This function takes some time to run. On the release build, it can take up to a second,
     /// while debug builds can take up to ten times longer. For this reason, it should only be
     /// called once, and the resulting [`FontSystem`] should be shared.

--- a/src/font/system/std.rs
+++ b/src/font/system/std.rs
@@ -24,6 +24,12 @@ pub struct FontSystem(FontSystemInner);
 
 impl FontSystem {
     /// Create a new [`FontSystem`], that allows access to any installed system fonts
+    /// 
+    /// # Timing
+    /// 
+    /// This function takes some time to run. On the release build, it can take up to a second,
+    /// while debug builds can take up to ten times longer. For this reason, it should only be
+    /// called once, and the resulting [`FontSystem`] should be shared.
     pub fn new() -> Self {
         Self::new_with_fonts(std::iter::empty())
     }


### PR DESCRIPTION
This PR adds a warning to the `FontSystem::new()` function that says that it may take some time. See also: #91 