### PR TITLE
Revert "Make `FontSystem` not self-referencing and update `fontdb` and `rustybuzz`"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,11 @@ documentation = "https://docs.rs/cosmic-text/latest/cosmic_text/"
 repository = "https://github.com/pop-os/cosmic-text"
 
 [dependencies]
-fontdb = { version = "0.13.0", default-features = false }
+fontdb = { version = "0.10.0", default-features = false }
 libm = "0.2.6"
 log = "0.4.17"
-rustybuzz = { version = "0.7.0", default-features = false, features = ["libm"] }
+ouroboros = "0.15.5"
+rustybuzz = { version = "0.6.0", default-features = false, features = ["libm"] }
 swash = { version = "0.1.6", optional = true }
 syntect = { version = "5.0.0", optional = true }
 sys-locale = { version = "0.2.3", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -112,7 +112,6 @@ allow = [
     "Apache-2.0",
     "Unicode-DFS-2016",
     "BSD-2-Clause",
-    "Zlib",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explicitly disallowed licenses
@@ -164,8 +163,8 @@ exceptions = [
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 #license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 
 [licenses.private]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::FontKey;
-
 /// Key for building a glyph cache
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CacheKey {
-    /// Font key
-    pub font_key: FontKey,
+    /// Font ID
+    pub font_id: fontdb::ID,
     /// Glyph ID
     pub glyph_id: u16,
     /// `f32` bits of font size
@@ -19,7 +17,7 @@ pub struct CacheKey {
 
 impl CacheKey {
     pub fn new(
-        font_key: FontKey,
+        font_id: fontdb::ID,
         glyph_id: u16,
         font_size: f32,
         pos: (f32, f32),
@@ -28,7 +26,7 @@ impl CacheKey {
         let (y, y_bin) = SubpixelBin::new(pos.1);
         (
             Self {
-                font_key,
+                font_id,
                 glyph_id,
                 font_size_bits: font_size.to_bits(),
                 x_bin,

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use unicode_script::Script;
 
-use crate::{Font, FontKey};
+use crate::Font;
 
 use self::platform::*;
 
@@ -25,8 +26,7 @@ mod platform;
 mod platform;
 
 pub struct FontFallbackIter<'a> {
-    db: &'a fontdb::Database,
-    font_keys: &'a [FontKey],
+    fonts: &'a [Arc<Font<'a>>],
     default_families: &'a [&'a str],
     default_i: usize,
     scripts: Vec<Script>,
@@ -39,15 +39,13 @@ pub struct FontFallbackIter<'a> {
 
 impl<'a> FontFallbackIter<'a> {
     pub fn new(
-        db: &'a fontdb::Database,
-        font_keys: &'a [FontKey],
+        fonts: &'a [Arc<Font<'a>>],
         default_families: &'a [&'a str],
         scripts: Vec<Script>,
         locale: &'a str,
     ) -> Self {
         Self {
-            db,
-            font_keys,
+            fonts,
             default_families,
             default_i: 0,
             scripts,
@@ -68,13 +66,12 @@ impl<'a> FontFallbackIter<'a> {
                 word
             );
         } else if self.other_i > 0 {
-            let font_key = self.font_keys[self.other_i - 1];
-            let font = Font::from_key(self.db, font_key).expect("invalid font key");
+            let font = &self.fonts[self.other_i - 1];
             log::debug!(
                 "Failed to find preset fallback for {:?} locale '{}', used '{}': '{}'",
                 self.scripts,
                 self.locale,
-                font.name(),
+                font.info.family,
                 word
             );
         } else if !self.scripts.is_empty() && self.common_i > 0 {
@@ -91,15 +88,14 @@ impl<'a> FontFallbackIter<'a> {
 }
 
 impl<'a> Iterator for FontFallbackIter<'a> {
-    type Item = Font<'a>;
+    type Item = &'a Arc<Font<'a>>;
     fn next(&mut self) -> Option<Self::Item> {
         while self.default_i < self.default_families.len() {
             let default_family = self.default_families[self.default_i];
             self.default_i += 1;
 
-            for font_key in self.font_keys.iter().copied() {
-                let font = Font::from_key(self.db, font_key).expect("invalid font key");
-                if font.contains_family(default_family) {
+            for font in self.fonts.iter() {
+                if font.info.family == default_family {
                     return Some(font);
                 }
             }
@@ -112,9 +108,8 @@ impl<'a> Iterator for FontFallbackIter<'a> {
             while self.script_i.1 < script_families.len() {
                 let script_family = script_families[self.script_i.1];
                 self.script_i.1 += 1;
-                for font_key in self.font_keys.iter().copied() {
-                    let font = Font::from_key(self.db, font_key).expect("invalid font key");
-                    if font.contains_family(script_family) {
+                for font in self.fonts.iter() {
+                    if font.info.family == script_family {
                         return Some(font);
                     }
                 }
@@ -134,9 +129,8 @@ impl<'a> Iterator for FontFallbackIter<'a> {
         while self.common_i < common_families.len() {
             let common_family = common_families[self.common_i];
             self.common_i += 1;
-            for font_key in self.font_keys.iter().copied() {
-                let font = Font::from_key(self.db, font_key).expect("invalid font key");
-                if font.contains_family(common_family) {
+            for font in self.fonts.iter() {
+                if font.info.family == common_family {
                     return Some(font);
                 }
             }
@@ -146,14 +140,10 @@ impl<'a> Iterator for FontFallbackIter<'a> {
         //TODO: do we need to do this?
         //TODO: do not evaluate fonts more than once!
         let forbidden_families = forbidden_fallback();
-        while self.other_i < self.font_keys.len() {
-            let font_key = self.font_keys[self.other_i];
-            let font = Font::from_key(self.db, font_key).expect("invalid font key");
+        while self.other_i < self.fonts.len() {
+            let font = &self.fonts[self.other_i];
             self.other_i += 1;
-            if forbidden_families
-                .iter()
-                .all(|family| !font.contains_family(family))
-            {
+            if !forbidden_families.contains(&font.info.family.as_str()) {
                 return Some(font);
             }
         }

--- a/src/font/matches.rs
+++ b/src/font/matches.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use crate::Font;
+
+/// Fonts that match a pattern
+pub struct FontMatches<'a> {
+    pub locale: &'a str,
+    pub default_family: String,
+    pub fonts: Vec<Arc<Font<'a>>>,
+}

--- a/src/font/system/redox.rs
+++ b/src/font/system/redox.rs
@@ -6,7 +6,7 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::{Attrs, Font, FontKey};
+use crate::{Attrs, Font, FontMatches};
 
 /// Access system fonts
 pub struct FontSystem {
@@ -44,7 +44,8 @@ impl FontSystem {
             let now = std::time::Instant::now();
 
             //TODO only do this on demand!
-            for id in db.faces().map(|face| face.id).collect::<Vec<_>>() {
+            for i in 0..db.faces().len() {
+                let id = db.faces()[i].id;
                 unsafe {
                     db.make_shared_face_data(id);
                 }
@@ -70,38 +71,33 @@ impl FontSystem {
 
     // Clippy false positive
     #[allow(clippy::needless_lifetimes)]
-    pub fn get_font<'a>(&'a self, key: FontKey) -> Option<Font<'a>> {
-        match Font::from_key(&self.db, key) {
-            Some(font) => Some(font),
+    pub fn get_font<'a>(&'a self, id: fontdb::ID) -> Option<Arc<Font<'a>>> {
+        let face = self.db.face(id)?;
+        match Font::new(face) {
+            Some(font) => Some(Arc::new(font)),
             None => {
-                let face = self.db.face(key.id)?;
                 log::warn!("failed to load font '{}'", face.post_script_name);
                 None
             }
         }
     }
 
-    pub fn get_font_key(&self, id: fontdb::ID) -> Option<FontKey> {
-        Some(Font::new(self.db.face(id)?)?.key())
-    }
-
-    pub fn get_font_matches<'a>(&'a self, attrs: Attrs) -> Arc<Vec<FontKey>> {
-        let mut font_keys = Vec::new();
+    pub fn get_font_matches<'a>(&'a self, attrs: Attrs) -> Arc<FontMatches<'a>> {
+        let mut fonts = Vec::new();
         for face in self.db.faces() {
             if !attrs.matches(face) {
                 continue;
             }
 
-            let font_key = match self.get_font_key(face.id) {
-                Some(font_key) => font_key,
-                None => continue,
-            };
-
-            if self.get_font(font_key).is_some() {
-                font_keys.push(font_key);
+            if let Some(font) = self.get_font(face.id) {
+                fonts.push(font);
             }
         }
 
-        Arc::new(font_keys)
+        Arc::new(FontMatches {
+            locale: &self.locale,
+            default_family: self.db.family_name(&attrs.family).to_string(),
+            fonts,
+        })
     }
 }

--- a/src/font/system/std.rs
+++ b/src/font/system/std.rs
@@ -1,22 +1,26 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#[cfg(feature = "swash")]
-use std::collections::hash_map::Entry;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
 
-use crate::{Attrs, AttrsOwned, Font, FontKey};
+use crate::{Attrs, AttrsOwned, Font, FontMatches};
 
-/// Access system fonts
-pub struct FontSystem {
+#[ouroboros::self_referencing]
+struct FontSystemInner {
     locale: String,
     db: fontdb::Database,
-    font_matches_cache: Mutex<HashMap<AttrsOwned, Arc<Vec<FontKey>>>>,
-    #[cfg(feature = "swash")]
-    font_key_cache: Mutex<HashMap<fontdb::ID, Option<FontKey>>>,
+    #[borrows(db)]
+    #[not_covariant]
+    font_cache: Mutex<HashMap<fontdb::ID, Option<Arc<Font<'this>>>>>,
+    #[borrows(locale, db)]
+    #[not_covariant]
+    font_matches_cache: Mutex<HashMap<AttrsOwned, Arc<FontMatches<'this>>>>,
 }
+
+/// Access system fonts
+pub struct FontSystem(FontSystemInner);
 
 impl FontSystem {
     /// Create a new [`FontSystem`], that allows access to any installed system fonts
@@ -71,7 +75,8 @@ impl FontSystem {
             let now = std::time::Instant::now();
 
             //TODO only do this on demand!
-            for id in db.faces().map(|face| face.id).collect::<Vec<_>>() {
+            for i in 0..db.faces().len() {
+                let id = db.faces()[i].id;
                 unsafe {
                     db.make_shared_face_data(id);
                 }
@@ -85,92 +90,97 @@ impl FontSystem {
             );
         }
 
-        Self {
-            locale,
-            db,
-            font_matches_cache: Mutex::new(HashMap::new()),
-            #[cfg(feature = "swash")]
-            font_key_cache: Mutex::new(HashMap::new()),
-        }
+        Self(
+            FontSystemInnerBuilder {
+                locale,
+                db,
+                font_cache_builder: |_| Mutex::new(HashMap::new()),
+                font_matches_cache_builder: |_, _| Mutex::new(HashMap::new()),
+            }
+            .build(),
+        )
     }
 
     pub fn locale(&self) -> &str {
-        &self.locale
+        self.0.borrow_locale()
     }
 
     pub fn db(&self) -> &fontdb::Database {
-        &self.db
+        self.0.borrow_db()
     }
 
     pub fn into_locale_and_db(self) -> (String, fontdb::Database) {
-        (self.locale, self.db)
+        let heads = self.0.into_heads();
+        (heads.locale, heads.db)
     }
 
     // Clippy false positive
     #[allow(clippy::needless_lifetimes)]
-    pub fn get_font<'a>(&'a self, key: FontKey) -> Option<Font<'a>> {
-        match Font::from_key(&self.db, key) {
-            Some(font) => Some(font),
-            None => {
-                let face = self.db.face(key.id)?;
-                log::warn!("failed to load font '{}'", face.post_script_name);
-                None
-            }
-        }
+    pub fn get_font<'a>(&'a self, id: fontdb::ID) -> Option<Arc<Font<'a>>> {
+        self.0.with(|fields| get_font(&fields, id))
     }
 
-    #[cfg(feature = "swash")]
-    pub fn get_font_key(&self, id: fontdb::ID) -> Option<FontKey> {
-        let mut font_key_cache = self
-            .font_key_cache
-            .lock()
-            .expect("failed to lock font matches cache");
-        match font_key_cache.entry(id) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let key = self.db.face(id).and_then(Font::new).as_ref().map(Font::key);
-                entry.insert(key);
-                key
-            }
-        }
-    }
+    pub fn get_font_matches<'a>(&'a self, attrs: Attrs) -> Arc<FontMatches<'a>> {
+        self.0.with(|fields| {
+            let mut font_matches_cache = fields
+                .font_matches_cache
+                .lock()
+                .expect("failed to lock font matches cache");
+            //TODO: do not create AttrsOwned unless entry does not already exist
+            font_matches_cache
+                .entry(AttrsOwned::new(attrs))
+                .or_insert_with(|| {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let now = std::time::Instant::now();
 
-    #[cfg(not(feature = "swash"))]
-    pub fn get_font_key(&self, id: fontdb::ID) -> Option<FontKey> {
-        Some(Font::new(self.db.face(id)?)?.key())
-    }
+                    let mut fonts = Vec::new();
+                    for face in fields.db.faces() {
+                        if !attrs.matches(face) {
+                            continue;
+                        }
 
-    pub fn get_font_matches(&self, attrs: Attrs) -> Arc<Vec<FontKey>> {
-        let mut font_matches_cache = self
-            .font_matches_cache
-            .lock()
-            .expect("failed to lock font matches cache");
-        //TODO: do not create AttrsOwned unless entry does not already exist
-        font_matches_cache
-            .entry(AttrsOwned::new(attrs))
-            .or_insert_with(|| {
-                #[cfg(not(target_arch = "wasm32"))]
-                let now = std::time::Instant::now();
-
-                let mut font_keys = Vec::new();
-                for face in self.db.faces() {
-                    if !attrs.matches(face) {
-                        continue;
+                        if let Some(font) = get_font(&fields, face.id) {
+                            fonts.push(font);
+                        }
                     }
 
-                    if let Some(key) = self.get_font_key(face.id) {
-                        font_keys.push(key);
+                    let font_matches = Arc::new(FontMatches {
+                        locale: fields.locale,
+                        default_family: fields.db.family_name(&attrs.family).to_string(),
+                        fonts,
+                    });
+
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        let elapsed = now.elapsed();
+                        log::debug!("font matches for {:?} in {:?}", attrs, elapsed);
                     }
-                }
 
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    let elapsed = now.elapsed();
-                    log::debug!("font matches for {:?} in {:?}", attrs, elapsed);
-                }
-
-                Arc::new(font_keys)
-            })
-            .clone()
+                    font_matches
+                })
+                .clone()
+        })
     }
+}
+
+fn get_font<'b>(
+    fields: &ouroboros_impl_font_system_inner::BorrowedFields<'_, 'b>,
+    id: fontdb::ID,
+) -> Option<Arc<Font<'b>>> {
+    fields
+        .font_cache
+        .lock()
+        .expect("failed to lock font cache")
+        .entry(id)
+        .or_insert_with(|| {
+            let face = fields.db.face(id)?;
+            match Font::new(face) {
+                Some(font) => Some(Arc::new(font)),
+                None => {
+                    log::warn!("failed to load font '{}'", face.post_script_name);
+                    None
+                }
+            }
+        })
+        .clone()
 }

--- a/src/swash.rs
+++ b/src/swash.rs
@@ -20,10 +20,10 @@ fn swash_image(
     context: &mut ScaleContext,
     cache_key: CacheKey,
 ) -> Option<SwashImage> {
-    let font = match font_system.get_font(cache_key.font_key) {
+    let font = match font_system.get_font(cache_key.font_id) {
         Some(some) => some,
         None => {
-            log::warn!("did not find font {:?}", cache_key.font_key.id);
+            log::warn!("did not find font {:?}", cache_key.font_id);
             return None;
         }
     };
@@ -63,10 +63,10 @@ fn swash_outline_commands(
 ) -> Option<Vec<swash::zeno::Command>> {
     use swash::zeno::PathData as _;
 
-    let font = match font_system.get_font(cache_key.font_key) {
+    let font = match font_system.get_font(cache_key.font_id) {
         Some(some) => some,
         None => {
-            log::warn!("did not find font {:?}", cache_key.font_key.id);
+            log::warn!("did not find font {:?}", cache_key.font_id);
             return None;
         }
     };


### PR DESCRIPTION
Reverts pop-os/cosmic-text#89, as it makes the editor test very slow