### PR TITLE
Fix `f32` clippy warnings

### DIFF
--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -285,7 +285,6 @@ impl Application for Window {
         );
 
         let font_size_picker = {
-            let editor = self.editor.lock().unwrap();
             pick_list(
                 FontSize::all(),
                 Some(self.font_size),

--- a/examples/editor-libcosmic/src/text.rs
+++ b/examples/editor-libcosmic/src/text.rs
@@ -116,7 +116,7 @@ where
             height += self.metrics.line_height;
         }
 
-        let size = Size::new(width as f32, height as f32);
+        let size = Size::new(width, height);
 
         log::debug!("layout {:?} in {:?}", size, instant.elapsed());
 

--- a/examples/editor-libcosmic/src/text_box.rs
+++ b/examples/editor-libcosmic/src/text_box.rs
@@ -103,7 +103,7 @@ where
             }
         }
 
-        let height = layout_lines as f32 * editor.buffer().metrics().line_height as f32;
+        let height = layout_lines as f32 * editor.buffer().metrics().line_height;
         let size = Size::new(limits.max().width, height);
         log::info!("size {:?}", size);
 
@@ -212,7 +212,7 @@ where
             handle,
             Rectangle::new(
                 layout.position() + [self.padding.left as f32, self.padding.top as f32].into(),
-                Size::new(view_w as f32, view_h as f32),
+                Size::new(view_w, view_h),
             ),
         );
 


### PR DESCRIPTION
This fixes the clippy warnings introduced by the change to use `f32` for lengths.