### PR TITLE
Update example dependencies

### DIFF
--- a/examples/editor-libcosmic/Cargo.toml
+++ b/examples/editor-libcosmic/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 cosmic-text = { path = "../../", features = ["syntect"] }
-env_logger = "0.9"
-fontdb = "0.9"
+env_logger = "0.10"
+fontdb = "0.13"
 lazy_static = "1.4"
 log = "0.4"
 
@@ -21,7 +21,7 @@ features = ["wgpu", "winit"]
 #path = "../../../libcosmic"
 
 [dependencies.rfd]
-version = "0.10"
+version = "0.11"
 #TODO: iced portal
 #default-features = false
 #features = ["xdg-portal"]

--- a/examples/editor-orbclient/Cargo.toml
+++ b/examples/editor-orbclient/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 cosmic-text = { path = "../..", features = ["syntect"] }
-env_logger = "0.9"
-fontdb = "0.9"
+env_logger = "0.10"
+fontdb = "0.13"
 log = "0.4"
 orbclient = "0.3.35"
 unicode-segmentation = "1.7"

--- a/examples/editor-test/Cargo.toml
+++ b/examples/editor-test/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 cosmic-text = { path = "../../" }
-env_logger = "0.9"
-fontdb = "0.9"
+env_logger = "0.10"
+fontdb = "0.13"
 log = "0.4"
 orbclient = "0.3.35"
 unicode-segmentation = "1.7"

--- a/examples/rich-text/Cargo.toml
+++ b/examples/rich-text/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 cosmic-text = { path = "../../" }
-env_logger = "0.9"
-fontdb = "0.9"
+env_logger = "0.10"
+fontdb = "0.13"
 log = "0.4"
 orbclient = "0.3.35"

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 cosmic-text = { path = "../../" }
-env_logger = "0.9"
-fontdb = "0.9"
+env_logger = "0.10"
+fontdb = "0.13"
 log = "0.4"
 termion = "2.0"


### PR DESCRIPTION
The library crate has already updated `fontdb`, so the examples should too.