### PR TITLE
Allow discarding of unused fonts

### DIFF
--- a/src/font/system/no_std.rs
+++ b/src/font/system/no_std.rs
@@ -61,6 +61,8 @@ impl FontSystem {
 
         Arc::new(ids)
     }
+
+    pub fn discard_unused_fonts(&mut self) {}
 }
 
 fn get_font(db: &fontdb::Database, id: fontdb::ID) -> Option<Arc<Font>> {

--- a/src/font/system/std.rs
+++ b/src/font/system/std.rs
@@ -117,6 +117,21 @@ impl FontSystem {
             })
             .clone()
     }
+
+    pub fn discard_unused_fonts(&mut self) {
+        self.font_cache.retain(|_, font| {
+            if let Some(font) = font {
+                if Arc::strong_count(font) == 1 {
+                    self.db.make_face_data_unshared(font.id());
+                    false
+                } else {
+                    true
+                }
+            } else {
+                true
+            }
+        });
+    }
 }
 
 fn get_font(


### PR DESCRIPTION
With these changes, `BufferLine` keeps track of the fonts used when it is shaped. It also adds a `FontSystem::discard_unused_fonts` method that removes those fonts that aren't references outside the font cache. 

I initially tried to implement this using `Weak`, to remove the need for the user to call `discard_unused_fonts`, but this had several issues:
- Like #89, the `editor-test` regressed due to many Font recreations, despite trying to hold onto the `Arc<Font>`s for as long as reasonably possible.
- Dropping `Font` is not enough for a true cleanup, because we would want to call `make_face_data_unshared` to free the memory mapping of unused fonts. This requires mutable access to the font database, which we cannot get during `Font::drop`.

I think having to call `discard_unused_fonts` is not the worst thing, we could also add methods to estimate the memory usage of cached fonts which could help users to decide when to discard unused fonts to free memory. 