### PR TITLE
Use doc_auto_cfg for docs generation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,8 +12,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    # Right now the doc_cfg and auto_doc_cfg features require nightly
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
     - name: Build documentation
-      run: cargo doc --verbose
+      run: cargo +nightly doc --verbose --all-features
+      env:
+        RUSTDOCFLAGS: --cfg docsrs
     - name: Deploy documentation
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ std = [
 ]
 vi = ["syntect"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [workspace]
 members = [
   "examples/*",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,11 @@
 //! });
 //! ```
 
+// If the docsrs feature is enabled, use nightly documentation features.
+//
+// This can be locally tested using RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --all-features
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 // Not interested in these lints
 #![allow(clippy::new_without_default)]
 // TODO: address occurrences and then deny


### PR DESCRIPTION
This is done when generating docs on docs.rs and locally with `RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --all-features`

There seems to be some bugs with the labels however:

There does seem to be a rustdoc bug when generating the labels as `SwashImage` fails to get a feature label automatically assigned to the type, but the functions have the label.

Also `FontSystem` seems to get an `std` label even though it is available `no_std`. I imagine that could be fixed by reworking the reexports.

![Screenshot 2023-03-13 at 21-02-48 cosmic_text - Rust](https://user-images.githubusercontent.com/30619168/224874845-a3df3e6b-113e-4d81-a621-5de4f1643142.png)