### PR TITLE
Warn on clippy::std_instead_of_core and other related lints.

### DIFF
--- a/src/font/system/std.rs
+++ b/src/font/system/std.rs
@@ -2,8 +2,9 @@
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::Mutex,
 };
+use alloc::sync::Arc;
 
 use crate::{Attrs, AttrsOwned, Font, FontMatches};
 
@@ -31,7 +32,7 @@ impl FontSystem {
     /// while debug builds can take up to ten times longer. For this reason, it should only be
     /// called once, and the resulting [`FontSystem`] should be shared.
     pub fn new() -> Self {
-        Self::new_with_fonts(std::iter::empty())
+        Self::new_with_fonts(core::iter::empty())
     }
 
     pub fn new_with_fonts(fonts: impl Iterator<Item = fontdb::Source>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,10 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 // Ensure numbers are readable
 #![warn(clippy::unreadable_literal)]
+// Warn if any std or alloc types are used when the types are available in alloc or core instead.
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
+#![warn(clippy::alloc_instead_of_core)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;


### PR DESCRIPTION
Primarily to let users know that some code might not compile if no_std mode is enabled.

This may be unnessecary for the `std` module of FontSystem, but it can make copying code between the two easier if needed.