### PR TITLE
Expose `rustybuzz` in the public API

### DIFF
--- a/src/font/system/mod.rs
+++ b/src/font/system/mod.rs
@@ -10,8 +10,9 @@ pub use self::std::*;
 #[cfg(feature = "std")]
 mod std;
 
-// re-export fontdb
+// re-export fontdb and rustybuzz
 pub use fontdb;
+pub use rustybuzz;
 
 /// A value borrowed together with an [`FontSystem`]
 pub struct BorrowedWithFontSystem<'a, T> {


### PR DESCRIPTION
This exposes `rustybuzz` on top of `fontdb`. This is in particular useful if you want to query the font for additional information. This is already publicly exposed via `Font::rustybuzz()`, but the types were not re-exported, so it was impossible to properly use that function.