### PR TITLE
Allow buffer reuse in `BufferLine`

### DIFF
--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -38,13 +38,11 @@ impl BufferLine {
     ///
     /// Will reset shape and layout if it differs from current text and attributes list.
     /// Returns true if the line was reset
-    pub fn set_text<T: AsRef<str> + Into<String>>(
-        &mut self,
-        text: T,
-        attrs_list: AttrsList,
-    ) -> bool {
-        if text.as_ref() != self.text || attrs_list != self.attrs_list {
-            self.text = text.into();
+    pub fn set_text<T: AsRef<str>>(&mut self, text: T, attrs_list: AttrsList) -> bool {
+        let text = text.as_ref();
+        if text != self.text || attrs_list != self.attrs_list {
+            self.text.clear();
+            self.text.push_str(text);
             self.attrs_list = attrs_list;
             self.reset();
             true


### PR DESCRIPTION
With the way `BufferLine::set_text` was written, you would always clone the `String` / `str` that you are passing in, resulting in the function almost not being any better than simply creating a new `BufferLine`. This ensures the internal buffer is reused.