### PR TITLE
Fix `FontSystem::new_with_locale_and_db` Signature

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -243,6 +243,9 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
+    # TODO: We allow syn 1.0 during the transition to syn 2.0. Remove this when
+    # syn is not in the dependency tree anymore.
+    { name = "syn", version = "1" }
     #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate

--- a/examples/editor-libcosmic/src/text_box.rs
+++ b/examples/editor-libcosmic/src/text_box.rs
@@ -10,7 +10,7 @@ use cosmic::{
         mouse::{self, Button, Event as MouseEvent, ScrollDelta},
         renderer,
         widget::{self, tree, Widget},
-        Padding, {Color, Element, Length, Point, Rectangle, Shell, Size},
+        Color, Element, Length, Padding, Point, Rectangle, Shell, Size,
     },
     theme::{Theme, ThemeType},
 };
@@ -227,7 +227,9 @@ where
 
         // Scale metrics
         let metrics = editor.buffer().metrics();
-        editor.buffer_mut().set_metrics(metrics.scale(style.scale_factor as f32));
+        editor
+            .buffer_mut()
+            .set_metrics(metrics.scale(style.scale_factor as f32));
 
         // Set size
         editor.buffer_mut().set_size(image_w as f32, image_h as f32);

--- a/src/font/system/no_std.rs
+++ b/src/font/system/no_std.rs
@@ -28,11 +28,8 @@ impl FontSystem {
         Self { locale, db }
     }
 
-    pub fn new_with_locale_and_db(locale: &str, db: fontdb::Database) -> Self {
-        Self {
-            locale: locale.to_string(),
-            db,
-        }
+    pub fn new_with_locale_and_db(locale: String, db: fontdb::Database) -> Self {
+        Self { locale, db }
     }
 
     pub fn locale(&self) -> &str {


### PR DESCRIPTION
It turns out that the `no_std` version of `FontSystem::new_with_locale_and_db` doesn't match the `std` version. This fixes that.