### PR TITLE
Fix WebAssembly support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ouroboros = { version = "0.15.5", default-features = false }
 rustybuzz = { version = "0.7.0", default-features = false, features = ["libm"] }
 swash = { version = "0.1.6", optional = true }
 syntect = { version = "5.0.0", optional = true }
-sys-locale = { version = "0.2.3", optional = true }
+sys-locale = { version = "0.3.0", optional = true }
 unicode-linebreak = "0.1.4"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.0"
@@ -41,6 +41,7 @@ std = [
   "unicode-bidi/std",
 ]
 vi = ["syntect"]
+wasm-web = ["sys-locale?/js"]
 
 [workspace]
 members = [


### PR DESCRIPTION
There was a problem in the upstream `sys-locale` crate where it assumed that every WebAssembly target can use `wasm-bindgen` just fine. This however is not the case, as `wasm-bindgen` and the ecosystem around it are specifically to target the web. In reality there however are at least the following 4 "targets" (with possibly more in the future):
 - WebAssembly on the web
 - Freestanding WebAssembly
 - WebAssembly with WASI
 - WebAssembly with Emscripten

These are all supported properly through `sys-locale` 0.3.0 now. However because "WebAssembly on the web" unfortunately is not its own target and instead uses `wasm32-unknown-unknown`, just like freestanding WebAssembly, the only way to differentiate between them is through a feature. This is the best practice and is done throughout the ecosystem. Here the feature `wasm-web` is introduced that properly forwards it to `sys-locale` and possibly other crates in the future.