### PR TITLE
Update terminal example using `colored`

### DIFF
--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
+colored = "2.0"
 cosmic-text = { path = "../../" }
 env_logger = "0.10"
 fontdb = "0.13"
 log = "0.4"
-termion = "2.0"


### PR DESCRIPTION
The terminal example didn't work for me on Windows because `termion` is not supported on Windows.

- Removed the `termion` dependency
- Added `colored` as a dependency
- Instead of terminal control sequences, I emulate a canvas, write the pixels to a string, and print that to the terminal

I also added the ability to pass text as an argument.
![image](https://github.com/pop-os/cosmic-text/assets/38416468/aa6806fb-9ab3-4da6-87de-07f3654ba2a6)

Fixes part of #46