### PR TITLE
Fix alignment when using `Wrap::None`

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -663,9 +663,23 @@ impl ShapeLine {
 
         if wrap == Wrap::None {
             for (span_index, span) in self.spans.iter().enumerate() {
-                current_visual_line
-                    .ranges
-                    .push((span_index, (0, 0), (span.words.len(), 0)));
+                let mut word_range_width = 0.;
+                let mut number_of_blanks: u32 = 0;
+                for word in span.words.iter() {
+                    let word_width = font_size * word.x_advance;
+                    word_range_width += word_width;
+                    if word.blank {
+                        number_of_blanks += 1;
+                    }
+                }
+                add_to_visual_line(
+                    &mut current_visual_line,
+                    span_index,
+                    (0, 0),
+                    (span.words.len(), 0),
+                    word_range_width,
+                    number_of_blanks,
+                );
             }
         } else {
             let mut fit_x = line_width;


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-text/issues/130

Some review of this would be a good idea as I am unfamiliar with cosmic-text's codebase, and just pattern matched the fix based on the description on the problem in #130 ("the `w` property of `VisualLine` is not updated"), and looking at how this was handled in the surrounding code for the other `Wrap` configurations. However it is verified as actually fixing #130 in Vizia.