### PR TITLE
Remove the dependency on ouroboros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/pop-os/cosmic-text"
 fontdb = { version = "0.13.0", default-features = false }
 libm = "0.2.6"
 log = "0.4.17"
-ouroboros = { version = "0.15.5", default-features = false }
+aliasable = "0.1.3"
 rustybuzz = { version = "0.7.0", default-features = false, features = ["libm"] }
 swash = { version = "0.1.6", optional = true }
 syntect = { version = "5.0.0", optional = true }
@@ -35,7 +35,6 @@ no_std = [
 std = [
   "fontdb/memmap",
   "fontdb/std",
-  "ouroboros/std",
   "rustybuzz/std",
   "sys-locale",
   "unicode-bidi/std",


### PR DESCRIPTION
This reduces compilation time by removing a dependency on syn and other dependencies of ouroboros_macros. In addition it saves a lot of unused codegened methods.

On my laptop (2 core + HT) this reduces compilation time by ~20%. On a many core system this doesn't help much though as the critical path path consists of both ttf-parser -> rustybuzz and swash. Further gains will likely need to be made by reducing compilation time for these crates.

```
# main
Benchmark 1: cargo build
  Time (mean ± σ):     25.150 s ±  0.167 s    [User: 84.414 s, System: 7.335 s]
  Range (min … max):   24.909 s … 25.444 s    10 runs

# this PR
Benchmark 1: cargo build
  Time (mean ± σ):     19.819 s ±  0.226 s    [User: 67.754 s, System: 5.592 s]
  Range (min … max):   19.492 s … 20.140 s    10 runs
```

The code is based on an expansion of the ouroboros macro, cleaned up to remove all unused methods and inline most functions that are only called once.