### PR TITLE
Add light syntax highligher to libcosmic example

### DIFF
--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -268,6 +268,13 @@ impl Application for Window {
                 ));
 
                 let mut editor = self.editor.lock().unwrap();
+
+                // Update the syntax color theme
+                match theme {
+                    "Light" => editor.update_theme("base16-ocean.light"),
+                    "Dark" | _ => editor.update_theme("base16-eighties.dark"),
+                };
+
                 update_attrs(&mut *editor, self.attrs);
             }
         }

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -60,6 +60,19 @@ impl<'a> SyntaxEditor<'a> {
         })
     }
 
+    /// Modifies the theme of the [`SyntaxEditor`], returning false if the theme is missing
+    pub fn update_theme(&mut self, theme_name: &str) -> bool {
+        if let Some(theme) = self.syntax_system.theme_set.themes.get(theme_name) {
+            self.theme = theme;
+            self.highlighter = Highlighter::new(theme);
+            self.syntax_cache.clear();
+
+            true
+        } else {
+            false
+        }
+    }
+
     /// Load text from a file, and also set syntax to the best option
     ///
     /// ## Errors


### PR DESCRIPTION
Closes #112

The syntax highlighter is now set to a light themed one in light mode in order for the text to be legible.