### PR TITLE
WIP Multiple font size / line height spans

### DIFF
--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -47,8 +47,9 @@ fn main() {
         .set_size(window.width() as f32, window.height() as f32);
 
     let attrs = Attrs::new()
-        .size(editor.buffer().metrics().font_size_)
-        .line_height(LineHeight::Absolute(editor.buffer().metrics().line_height_));
+        .size(32.0)
+        .line_height(LineHeight::Absolute(44.0))
+        .scale(display_scale);
     let serif_attrs = attrs.family(Family::Serif);
     let mono_attrs = attrs.family(Family::Monospace);
     let comic_attrs = attrs.family(Family::Name("Comic Neue"));

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, AttrsList, Buffer, BufferLine, Color, Edit, Editor, Family, FontSystem,
-    LineHeight, Shaping, Style, SwashCache, Weight,
+    Action, Attrs, Buffer, Color, Edit, Editor, Family, FontSystem, LineHeight, Shaping, Style,
+    SwashCache, Weight,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
         .buffer_mut()
         .set_size(window.width() as f32, window.height() as f32);
 
-    let font_size = editor.buffer().metrics().font_size;
+    let font_size = editor.buffer().metrics().font_size_;
     let attrs = Attrs::new().size(font_size);
     let serif_attrs = attrs.family(Family::Serif).size(attrs.font_size * 1.5);
     let mono_attrs = attrs.family(Family::Monospace);

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -46,8 +46,9 @@ fn main() {
         .buffer_mut()
         .set_size(window.width() as f32, window.height() as f32);
 
-    let attrs = Attrs::new();
-    let serif_attrs = attrs.family(Family::Serif);
+    let font_size = editor.buffer().metrics().font_size;
+    let attrs = Attrs::new().size(font_size);
+    let serif_attrs = attrs.family(Family::Serif).size(attrs.font_size * 1.5);
     let mono_attrs = attrs.family(Family::Monospace);
     let comic_attrs = attrs.family(Family::Name("Comic Neue"));
 
@@ -97,13 +98,48 @@ fn main() {
         ("B", attrs.color(Color::rgb(0x00, 0x00, 0xFF))),
         ("O", attrs.color(Color::rgb(0x4B, 0x00, 0x82))),
         ("W ", attrs.color(Color::rgb(0x94, 0x00, 0xD3))),
-        ("Red ", attrs.color(Color::rgb(0xFF, 0x00, 0x00))),
-        ("Orange ", attrs.color(Color::rgb(0xFF, 0x7F, 0x00))),
-        ("Yellow ", attrs.color(Color::rgb(0xFF, 0xFF, 0x00))),
-        ("Green ", attrs.color(Color::rgb(0x00, 0xFF, 0x00))),
-        ("Blue ", attrs.color(Color::rgb(0x00, 0x00, 0xFF))),
-        ("Indigo ", attrs.color(Color::rgb(0x4B, 0x00, 0x82))),
-        ("Violet ", attrs.color(Color::rgb(0x94, 0x00, 0xD3))),
+        (
+            "Red ",
+            attrs
+                .color(Color::rgb(0xFF, 0x00, 0x00))
+                .size(attrs.font_size * 1.9),
+        ),
+        (
+            "Orange ",
+            attrs
+                .color(Color::rgb(0xFF, 0x7F, 0x00))
+                .size(attrs.font_size * 1.6),
+        ),
+        (
+            "Yellow ",
+            attrs
+                .color(Color::rgb(0xFF, 0xFF, 0x00))
+                .size(attrs.font_size * 1.3),
+        ),
+        (
+            "Green ",
+            attrs
+                .color(Color::rgb(0x00, 0xFF, 0x00))
+                .size(attrs.font_size * 1.0),
+        ),
+        (
+            "Blue ",
+            attrs
+                .color(Color::rgb(0x00, 0x00, 0xFF))
+                .size(attrs.font_size * 0.8),
+        ),
+        (
+            "Indigo ",
+            attrs
+                .color(Color::rgb(0x4B, 0x00, 0x82))
+                .size(attrs.font_size * 0.6),
+        ),
+        (
+            "Violet ",
+            attrs
+                .color(Color::rgb(0x94, 0x00, 0xD3))
+                .size(attrs.font_size * 0.4),
+        ),
         ("U", attrs.color(Color::rgb(0x94, 0x00, 0xD3))),
         ("N", attrs.color(Color::rgb(0x4B, 0x00, 0x82))),
         ("I", attrs.color(Color::rgb(0x00, 0x00, 0xFF))),

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, Buffer, Color, Edit, Editor, Family, FontSystem, Metrics, Shaping, Style,
-    SwashCache, Weight,
+    Action, Attrs, AttrsList, Buffer, BufferLine, Color, Edit, Editor, Family, FontSystem,
+    LineHeight, Metrics, Shaping, Style, SwashCache, Weight,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{
@@ -46,9 +46,10 @@ fn main() {
         .buffer_mut()
         .set_size(window.width() as f32, window.height() as f32);
 
-    let font_size = editor.buffer().metrics().font_size_;
-    let attrs = Attrs::new().size(font_size);
-    let serif_attrs = attrs.family(Family::Serif).size(attrs.font_size * 1.5);
+    let attrs = Attrs::new()
+        .size(editor.buffer().metrics().font_size_)
+        .line_height(LineHeight::Absolute(editor.buffer().metrics().line_height_));
+    let serif_attrs = attrs.family(Family::Serif);
     let mono_attrs = attrs.family(Family::Monospace);
     let comic_attrs = attrs.family(Family::Name("Comic Neue"));
 
@@ -102,43 +103,50 @@ fn main() {
             "Red ",
             attrs
                 .color(Color::rgb(0xFF, 0x00, 0x00))
-                .size(attrs.font_size * 1.9),
+                .size(attrs.font_size * 1.9)
+                .line_height(LineHeight::Proportional(0.9)),
         ),
         (
             "Orange ",
             attrs
                 .color(Color::rgb(0xFF, 0x7F, 0x00))
-                .size(attrs.font_size * 1.6),
+                .size(attrs.font_size * 1.6)
+                .line_height(LineHeight::Proportional(1.0)),
         ),
         (
             "Yellow ",
             attrs
                 .color(Color::rgb(0xFF, 0xFF, 0x00))
-                .size(attrs.font_size * 1.3),
+                .size(attrs.font_size * 1.3)
+                .line_height(LineHeight::Proportional(1.1)),
         ),
         (
             "Green ",
             attrs
                 .color(Color::rgb(0x00, 0xFF, 0x00))
-                .size(attrs.font_size * 1.0),
+                .size(attrs.font_size * 1.0)
+                .line_height(LineHeight::Proportional(1.2)),
         ),
         (
             "Blue ",
             attrs
                 .color(Color::rgb(0x00, 0x00, 0xFF))
-                .size(attrs.font_size * 0.8),
+                .size(attrs.font_size * 0.8)
+                .line_height(LineHeight::Proportional(1.3)),
         ),
         (
             "Indigo ",
             attrs
                 .color(Color::rgb(0x4B, 0x00, 0x82))
-                .size(attrs.font_size * 0.6),
+                .size(attrs.font_size * 0.6)
+                .line_height(LineHeight::Proportional(1.4)),
         ),
         (
             "Violet ",
             attrs
                 .color(Color::rgb(0x94, 0x00, 0xD3))
-                .size(attrs.font_size * 0.4),
+                .size(attrs.font_size * 0.4)
+                .line_height(LineHeight::Proportional(1.5)),
         ),
         ("U", attrs.color(Color::rgb(0x94, 0x00, 0xD3))),
         ("N", attrs.color(Color::rgb(0x4B, 0x00, 0x82))),

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -2,7 +2,7 @@
 
 use cosmic_text::{
     Action, Attrs, AttrsList, Buffer, BufferLine, Color, Edit, Editor, Family, FontSystem,
-    LineHeight, Metrics, Shaping, Style, SwashCache, Weight,
+    LineHeight, Shaping, Style, SwashCache, Weight,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{
@@ -36,9 +36,7 @@ fn main() {
     )
     .unwrap();
 
-    let mut editor = Editor::new(Buffer::new_empty(
-        Metrics::new(32.0, 44.0).scale(display_scale),
-    ));
+    let mut editor = Editor::new(Buffer::new_empty());
 
     let mut editor = editor.borrow_with(&mut font_system);
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -99,6 +99,31 @@ impl FamilyOwned {
     }
 }
 
+/// Determines the line height and strategy.
+/// The actual height of a line will be determined by the largest logical line height in a line.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LineHeight {
+    /// Represents a line height that is proportional to the font size.
+    Proportional(f32),
+    /// Represents an absolute line height, independent of the font size.
+    Absolute(f32),
+}
+
+impl LineHeight {
+    pub fn height(&self, font_size: f32) -> f32 {
+        match self {
+            LineHeight::Proportional(height) => *height * font_size,
+            LineHeight::Absolute(height) => *height,
+        }
+    }
+}
+
+impl Default for LineHeight {
+    fn default() -> Self {
+        Self::Proportional(1.2)
+    }
+}
+
 /// Text attributes
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Attrs<'a> {
@@ -113,6 +138,8 @@ pub struct Attrs<'a> {
     pub metadata: usize,
     // TODO: extract
     pub font_size: f32,
+    // TODO: extract
+    pub line_height: LineHeight,
 }
 
 impl<'a> Attrs<'a> {
@@ -127,6 +154,7 @@ impl<'a> Attrs<'a> {
             style: Style::Normal,
             weight: Weight::NORMAL,
             font_size: 16.0,
+            line_height: LineHeight::Proportional(1.2),
             metadata: 0,
         }
     }
@@ -140,6 +168,12 @@ impl<'a> Attrs<'a> {
     /// Set font size
     pub fn size(mut self, size: f32) -> Self {
         self.font_size = size;
+        self
+    }
+
+    /// Set line_height
+    pub fn line_height(mut self, line_height: LineHeight) -> Self {
+        self.line_height = line_height;
         self
     }
 
@@ -219,6 +253,8 @@ pub struct AttrsOwned {
     pub metadata: usize,
     // TODO: extract
     pub font_size: f32,
+    // TODO: extract
+    pub line_height: LineHeight,
 }
 
 impl AttrsOwned {
@@ -231,6 +267,7 @@ impl AttrsOwned {
             weight: attrs.weight,
             metadata: attrs.metadata,
             font_size: attrs.font_size,
+            line_height: attrs.line_height,
         }
     }
 
@@ -243,6 +280,7 @@ impl AttrsOwned {
             weight: self.weight,
             metadata: self.metadata,
             font_size: self.font_size,
+            line_height: self.line_height,
         }
     }
 }

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -100,15 +100,19 @@ impl FamilyOwned {
 }
 
 /// Text attributes
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Attrs<'a> {
     //TODO: should this be an option?
+    // TODO: extract
     pub color_opt: Option<Color>,
     pub family: Family<'a>,
     pub stretch: Stretch,
     pub style: Style,
     pub weight: Weight,
+    // TODO: extract
     pub metadata: usize,
+    // TODO: extract
+    pub font_size: f32,
 }
 
 impl<'a> Attrs<'a> {
@@ -122,6 +126,7 @@ impl<'a> Attrs<'a> {
             stretch: Stretch::Normal,
             style: Style::Normal,
             weight: Weight::NORMAL,
+            font_size: 16.0,
             metadata: 0,
         }
     }
@@ -129,6 +134,12 @@ impl<'a> Attrs<'a> {
     /// Set [Color]
     pub fn color(mut self, color: Color) -> Self {
         self.color_opt = Some(color);
+        self
+    }
+
+    /// Set font size
+    pub fn size(mut self, size: f32) -> Self {
+        self.font_size = size;
         self
     }
 
@@ -180,16 +191,34 @@ impl<'a> Attrs<'a> {
     }
 }
 
+impl<'a> Eq for Attrs<'a> {}
+
+impl<'a> core::hash::Hash for Attrs<'a> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.color_opt.hash(state);
+        self.family.hash(state);
+        self.stretch.hash(state);
+        self.style.hash(state);
+        self.weight.hash(state);
+        self.metadata.hash(state);
+        self.font_size.to_bits().hash(state);
+    }
+}
+
 /// An owned version of [`Attrs`]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AttrsOwned {
     //TODO: should this be an option?
+    // TODO: extract
     pub color_opt: Option<Color>,
     pub family_owned: FamilyOwned,
     pub stretch: Stretch,
     pub style: Style,
     pub weight: Weight,
+    // TODO: extract
     pub metadata: usize,
+    // TODO: extract
+    pub font_size: f32,
 }
 
 impl AttrsOwned {
@@ -201,6 +230,7 @@ impl AttrsOwned {
             style: attrs.style,
             weight: attrs.weight,
             metadata: attrs.metadata,
+            font_size: attrs.font_size,
         }
     }
 
@@ -212,7 +242,22 @@ impl AttrsOwned {
             style: self.style,
             weight: self.weight,
             metadata: self.metadata,
+            font_size: self.font_size,
         }
+    }
+}
+
+impl Eq for AttrsOwned {}
+
+impl core::hash::Hash for AttrsOwned {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.color_opt.hash(state);
+        self.family_owned.hash(state);
+        self.stretch.hash(state);
+        self.style.hash(state);
+        self.weight.hash(state);
+        self.metadata.hash(state);
+        self.font_size.to_bits().hash(state);
     }
 }
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -109,6 +109,21 @@ pub enum LineHeight {
     Absolute(f32),
 }
 
+impl core::hash::Hash for LineHeight {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            LineHeight::Proportional(height) => {
+                state.write_u8(1);
+                height.to_bits().hash(state);
+            }
+            LineHeight::Absolute(height) => {
+                state.write_u8(2);
+                height.to_bits().hash(state);
+            }
+        }
+    }
+}
+
 impl LineHeight {
     pub fn height(&self, font_size: f32) -> f32 {
         match self {
@@ -323,6 +338,7 @@ impl core::hash::Hash for AttrsOwned {
         self.weight.hash(state);
         self.metadata.hash(state);
         self.font_size.to_bits().hash(state);
+        self.line_height.hash(state);
     }
 }
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -278,6 +278,7 @@ impl<'a> core::hash::Hash for Attrs<'a> {
         self.weight.hash(state);
         self.metadata.hash(state);
         self.font_size.to_bits().hash(state);
+        self.line_height.hash(state);
     }
 }
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -166,13 +166,24 @@ impl<'a> Attrs<'a> {
     }
 
     /// Set font size
+    /// 
+    /// # Panics
+    /// 
+    /// Will panic if font size is zero.
     pub fn size(mut self, size: f32) -> Self {
+        assert_ne!(inner, 0.0, "font size cannot be 0");
         self.font_size = size;
         self
     }
 
-    /// Set line_height
+    /// Set line height
+    /// 
+    /// # Panics
+    /// 
+    /// Will panic if line height is zero.
     pub fn line_height(mut self, line_height: LineHeight) -> Self {
+        let LineHeight::Absolute(inner) | LineHeight::Proportional(inner) = line_height;
+        assert_ne!(inner, 0.0, "line height cannot be 0");
         self.line_height = line_height;
         self
     }
@@ -224,7 +235,13 @@ impl<'a> Attrs<'a> {
             && self.weight == other.weight
     }
 
+    /// Scale the font size and line height
+    /// 
+    /// # Panics
+    /// 
+    /// Will panic if scale is zero.
     pub fn scale(mut self, scale: f32) -> Self {
+        assert_ne!(scale, 0.0, "scale cannot be 0");
         self.font_size = self.font_size * scale;
         if let LineHeight::Absolute(height) = self.line_height {
             self.line_height = LineHeight::Absolute(height * scale);

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -223,6 +223,14 @@ impl<'a> Attrs<'a> {
             && self.style == other.style
             && self.weight == other.weight
     }
+
+    pub fn scale(mut self, scale: f32) -> Self {
+        self.font_size = self.font_size * scale;
+        if let LineHeight::Absolute(height) = self.line_height {
+            self.line_height = LineHeight::Absolute(height * scale);
+        }
+        self
+    }
 }
 
 impl<'a> Eq for Attrs<'a> {}

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -166,23 +166,25 @@ impl<'a> Attrs<'a> {
     }
 
     /// Set font size
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Will panic if font size is zero.
     pub fn size(mut self, size: f32) -> Self {
-        assert_ne!(inner, 0.0, "font size cannot be 0");
+        assert_ne!(size, 0.0, "font size cannot be 0");
         self.font_size = size;
         self
     }
 
     /// Set line height
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Will panic if line height is zero.
     pub fn line_height(mut self, line_height: LineHeight) -> Self {
-        let LineHeight::Absolute(inner) | LineHeight::Proportional(inner) = line_height;
+        let inner = match line_height {
+            LineHeight::Absolute(inner) | LineHeight::Proportional(inner) => inner,
+        };
         assert_ne!(inner, 0.0, "line height cannot be 0");
         self.line_height = line_height;
         self
@@ -236,9 +238,9 @@ impl<'a> Attrs<'a> {
     }
 
     /// Scale the font size and line height
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Will panic if scale is zero.
     pub fn scale(mut self, scale: f32) -> Self {
         assert_ne!(scale, 0.0, "scale cannot be 0");

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -610,13 +610,17 @@ impl Buffer {
         }
     }
 
-    /// Get the current scroll location
+    /// Get the current scroll location in terms of visual lines
     pub fn scroll(&self) -> i32 {
         self.scroll
     }
 
-    /// Set the current scroll location
+    /// Set the current scroll location in terms of visual lines.
+    ///
+    /// This is clamped to the visual lines of the buffer.
     pub fn set_scroll(&mut self, scroll: i32) {
+        let visual_lines = self.line_heights().len() as i32;
+        let scroll = scroll.clamp(0, visual_lines - 1);
         if scroll != self.scroll {
             self.scroll = scroll;
             self.redraw = true;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -390,7 +390,7 @@ impl Buffer {
         for line in &mut self.lines {
             if line.shape_opt().is_some() {
                 line.reset_layout();
-                line.layout(font_system, self.metrics.font_size, self.width, self.wrap);
+                line.layout(font_system, self.width, self.wrap);
             }
         }
 
@@ -415,13 +415,8 @@ impl Buffer {
             if line.shape_opt().is_none() {
                 reshaped += 1;
             }
-            let layout = line.layout_in_buffer(
-                &mut self.scratch,
-                font_system,
-                self.metrics.font_size,
-                self.width,
-                self.wrap,
-            );
+            let layout =
+                line.layout_in_buffer(&mut self.scratch, font_system, self.width, self.wrap);
             total_layout += layout.len() as i32;
         }
 
@@ -449,13 +444,8 @@ impl Buffer {
             if line.shape_opt().is_none() {
                 reshaped += 1;
             }
-            let layout = line.layout_in_buffer(
-                &mut self.scratch,
-                font_system,
-                self.metrics.font_size,
-                self.width,
-                self.wrap,
-            );
+            let layout =
+                line.layout_in_buffer(&mut self.scratch, font_system, self.width, self.wrap);
             if line_i == cursor.line {
                 let layout_cursor = self.layout_cursor(&cursor);
                 layout_i += layout_cursor.layout as i32;
@@ -538,7 +528,7 @@ impl Buffer {
         line_i: usize,
     ) -> Option<&[LayoutLine]> {
         let line = self.lines.get_mut(line_i)?;
-        Some(line.layout(font_system, self.metrics.font_size, self.width, self.wrap))
+        Some(line.layout(font_system, self.width, self.wrap))
     }
 
     /// Get the current [`Metrics`]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -852,11 +852,13 @@ impl Buffer {
         // - `start`, `end` refers to byte indices (usize)
         // - `left`, `top`, `right`, `bot`, `mid` refers to spatial coordinates (f32)
 
-        let last_run_index = self.layout_runs().count() - 1;
+        let Some(last_run_index) = self.layout_runs().count().checked_sub(1) else {
+            return None;
+        };
 
         let mut runs = self.layout_runs().enumerate();
 
-        // TODO: cache line_top, run.line_height(), and line_bot on LayoutRun
+        // TODO: consider caching line_top and line_bot on LayoutRun
 
         // 1. within the buffer, find the layout run (line) that contains the strike point
         // 2. within the layout run (line), find the glyph that contains the strike point

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -626,20 +626,19 @@ impl Buffer {
         let mut height = self.height;
         let line_heights = self.line_heights();
         if line_heights.is_empty() {
-            // this has never been laid out, so we can't know the height
+            // this has never been laid out, so we can't know the height yet
             return i32::MAX;
         }
-        let mut total_height = 0.0;
-        for (i, line_height) in line_heights.iter().skip(self.scroll as usize).enumerate() {
-            println!("{i}: line_height({line_height})");
-            total_height += line_height;
+        let mut i = 0;
+        let mut iter = line_heights.iter().skip(self.scroll as usize);
+        while let Some(line_height) = iter.next() {
             height -= line_height;
             if height <= 0.0 {
-                dbg!(self.scroll, i, total_height);
-                return i as i32;
+                break;
             }
+            i += 1;
         }
-        1
+        i
     }
 
     /// Set text of buffer, using provided attributes for each line by default

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -279,14 +279,18 @@ impl<'b> ExactSizeIterator for LayoutRunIter<'b> {}
 pub struct Buffer {
     /// [BufferLine]s (or paragraphs) of text in the buffer
     pub lines: Vec<BufferLine>,
+    /// The cached heights of visual lines
     line_heights: Vec<f32>,
+    /// The text bounding box width
     width: f32,
+    /// The text bounding box height
     height: f32,
+    /// The current scroll position in terms of visual lines
     scroll: i32,
-    /// True if a redraw is requires. Set to false after processing
+    /// True if a redraw is required. Set to false after processing
     redraw: bool,
+    /// The wrapping mode
     wrap: Wrap,
-
     /// Scratch buffer for shaping and laying out.
     scratch: ShapeBuffer,
 }
@@ -348,10 +352,12 @@ impl Buffer {
         log::debug!("relayout: {:?}", instant.elapsed());
     }
 
+    /// Get the cached heights of visual lines
     pub fn line_heights(&self) -> &[f32] {
         self.line_heights.as_slice()
     }
 
+    /// Update the cached heights of visual lines
     pub fn update_line_heights(&mut self) {
         #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
         let instant = std::time::Instant::now();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -228,7 +228,7 @@ impl<'b> Iterator for LayoutRunIter<'b> {
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(line) = self.buffer.lines.get(self.line_i) {
             let shape = line.shape_opt().as_ref()?;
-            let layout = line.layout_opt().as_ref()?;
+            let layout = line.layout_opt()?;
             while let Some(layout_line) = layout.get(self.layout_i) {
                 self.layout_i += 1;
 
@@ -482,7 +482,7 @@ impl Buffer {
         let line = &self.lines[cursor.line];
 
         //TODO: ensure layout is done?
-        let layout = line.layout_opt().as_ref().expect("layout not found");
+        let layout = line.layout_opt().expect("layout not found");
         for (layout_i, layout_line) in layout.iter().enumerate() {
             for (glyph_i, glyph) in layout_line.glyphs.iter().enumerate() {
                 let cursor_end =

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! This module contains the [`Buffer`] type which is the entry point for shaping and layout of text.
+//!
+//! A [`Buffer`] contains a list of [`BufferLine`]s and is used to compute the [`LayoutRun`]s.
+//!
+//! [`BufferLine`]s correspond to the paragraphs of text in the [`Buffer`].
+//! Each [`BufferLine`] contains a list of [`LayoutLine`]s, which represent the visual lines.
+//! `Buffer::line_heights` is a computed list of visual line heights.
+//!
+//! [`LayoutRun`]s represent the actually-visible visual lines,
+//! based on the [`Buffer`]'s scroll position, width, height and wrapping mode.
+
 #[cfg(not(feature = "std"))]
 use alloc::{
     string::{String, ToString},
@@ -112,9 +123,9 @@ impl LayoutCursor {
 /// A line of visible text for rendering
 #[derive(Debug)]
 pub struct LayoutRun<'a> {
-    /// The index of the original text line
+    /// The index of the original [`BufferLine`] (or paragraph) in the [`Buffer`]
     pub line_i: usize,
-    /// The original text line
+    /// The text of the original [`BufferLine`] (or paragraph)
     pub text: &'a str,
     /// True if the original paragraph direction is RTL
     pub rtl: bool,
@@ -277,17 +288,17 @@ impl<'b> ExactSizeIterator for LayoutRunIter<'b> {}
 /// A buffer of text that is shaped and laid out
 #[derive(Debug)]
 pub struct Buffer {
-    /// [BufferLine]s (or paragraphs) of text in the buffer
+    /// [BufferLine]s (or paragraphs) of text in the buffer.
     pub lines: Vec<BufferLine>,
-    /// The cached heights of visual lines
+    /// The cached heights of visual lines. Compute using [`Buffer::update_line_heights`].
     line_heights: Vec<f32>,
-    /// The text bounding box width
+    /// The text bounding box width.
     width: f32,
-    /// The text bounding box height
+    /// The text bounding box height.
     height: f32,
-    /// The current scroll position in terms of visual lines
+    /// The current scroll position in terms of visual lines.
     scroll: i32,
-    /// True if a redraw is required. Set to false after processing
+    /// True if a redraw is required. Set to false after processing.
     redraw: bool,
     /// The wrapping mode
     wrap: Wrap,
@@ -652,7 +663,7 @@ impl Buffer {
         i
     }
 
-    /// Get the number of lines that can be viewed in the buffer
+    /// Get the number of visual lines that can be viewed in the buffer
     pub fn visible_lines(&self) -> i32 {
         self.visible_lines_from(self.scroll as usize)
     }

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -210,19 +210,7 @@ impl BufferLine {
         width: f32,
         wrap: Wrap,
     ) -> &[LayoutLine] {
-        if self.layout_opt.is_none() {
-            self.wrap = wrap;
-            let align = self.align;
-            let shape = self.shape(font_system);
-
-            let layout = shape.layout(width, wrap, align);
-
-            let line_heights = layout.iter().map(|line| line.line_height()).collect();
-
-            self.layout_opt = Some(layout);
-            self.line_heights = Some(line_heights);
-        }
-        self.layout_opt.as_ref().expect("layout not found")
+        self.layout_in_buffer(&mut ShapeBuffer::default(), font_system, width, wrap)
     }
 
     /// Layout a line using a pre-existing shape buffer.

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -214,8 +214,11 @@ impl BufferLine {
             self.wrap = wrap;
             let align = self.align;
             let shape = self.shape(font_system);
+
             let layout = shape.layout(width, wrap, align);
+
             let line_heights = layout.iter().map(|line| line.line_height()).collect();
+
             self.layout_opt = Some(layout);
             self.line_heights = Some(line_heights);
         }
@@ -223,6 +226,8 @@ impl BufferLine {
     }
 
     /// Layout a line using a pre-existing shape buffer.
+    ///
+    /// Ensure that if this buffer line was laid out, you call [`Buffer::update_line_heights`] afterwards
     pub fn layout_in_buffer(
         &mut self,
         scratch: &mut ShapeBuffer,
@@ -234,9 +239,14 @@ impl BufferLine {
             self.wrap = wrap;
             let align = self.align;
             let shape = self.shape_in_buffer(scratch, font_system);
+
             let mut layout = Vec::with_capacity(1);
             shape.layout_to_buffer(scratch, width, wrap, align, &mut layout);
+
+            let line_heights = layout.iter().map(|line| line.line_height()).collect();
+
             self.layout_opt = Some(layout);
+            self.line_heights = Some(line_heights);
         }
         self.layout_opt.as_ref().expect("layout not found")
     }

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -200,7 +200,6 @@ impl BufferLine {
     pub fn layout(
         &mut self,
         font_system: &mut FontSystem,
-        font_size: f32,
         width: f32,
         wrap: Wrap,
     ) -> &[LayoutLine] {
@@ -208,7 +207,7 @@ impl BufferLine {
             self.wrap = wrap;
             let align = self.align;
             let shape = self.shape(font_system);
-            let layout = shape.layout(font_size, width, wrap, align);
+            let layout = shape.layout(width, wrap, align);
             self.layout_opt = Some(layout);
         }
         self.layout_opt.as_ref().expect("layout not found")
@@ -219,7 +218,6 @@ impl BufferLine {
         &mut self,
         scratch: &mut ShapeBuffer,
         font_system: &mut FontSystem,
-        font_size: f32,
         width: f32,
         wrap: Wrap,
     ) -> &[LayoutLine] {
@@ -228,7 +226,7 @@ impl BufferLine {
             let align = self.align;
             let shape = self.shape_in_buffer(scratch, font_system);
             let mut layout = Vec::with_capacity(1);
-            shape.layout_to_buffer(scratch, font_size, width, wrap, align, &mut layout);
+            shape.layout_to_buffer(scratch, width, wrap, align, &mut layout);
             self.layout_opt = Some(layout);
         }
         self.layout_opt.as_ref().expect("layout not found")

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -12,8 +12,7 @@ pub struct BufferLine {
     wrap: Wrap,
     align: Option<Align>,
     shape_opt: Option<ShapeLine>,
-    layout_opt: Option<Vec<LayoutLine>>,
-    line_heights: Option<Vec<f32>>,
+    layout_opt: Option<LayoutLines>,
     shaping: Shaping,
 }
 
@@ -29,7 +28,6 @@ impl BufferLine {
             align: None,
             shape_opt: None,
             layout_opt: None,
-            line_heights: None,
             shaping,
         }
     }
@@ -157,13 +155,11 @@ impl BufferLine {
     pub fn reset(&mut self) {
         self.shape_opt = None;
         self.layout_opt = None;
-        self.line_heights = None;
     }
 
     /// Reset only layout information
     pub fn reset_layout(&mut self) {
         self.layout_opt = None;
-        self.line_heights = None;
     }
 
     /// Check if shaping and layout information is cleared
@@ -191,7 +187,6 @@ impl BufferLine {
                 self.shaping,
             ));
             self.layout_opt = None;
-            self.line_heights = None;
         }
         self.shape_opt.as_ref().expect("shape not found")
     }
@@ -233,19 +228,31 @@ impl BufferLine {
 
             let line_heights = layout.iter().map(|line| line.line_height()).collect();
 
-            self.layout_opt = Some(layout);
-            self.line_heights = Some(line_heights);
+            self.layout_opt = Some(LayoutLines {
+                layout,
+                line_heights,
+            });
         }
-        self.layout_opt.as_ref().expect("layout not found")
+        self.layout_opt
+            .as_ref()
+            .map(|l| l.layout.as_ref())
+            .expect("layout not found")
     }
 
     /// Get line layout cache
-    pub fn layout_opt(&self) -> &Option<Vec<LayoutLine>> {
-        &self.layout_opt
+    pub fn layout_opt(&self) -> Option<&[LayoutLine]> {
+        self.layout_opt.as_ref().map(|l| l.layout.as_ref())
     }
 
-    /// Get line height cache, maps from [`Self::layout_opt`]
-    pub fn line_heights(&self) -> &Option<Vec<f32>> {
-        &self.line_heights
+    /// Get line height cache
+    pub fn line_heights(&self) -> Option<&[f32]> {
+        self.layout_opt.as_ref().map(|l| l.line_heights.as_ref())
     }
+}
+
+/// A list of [`LayoutLine`] in a [`BufferLine`] alongside their line heights
+#[derive(Debug)]
+struct LayoutLines {
+    layout: Vec<LayoutLine>,
+    line_heights: Vec<f32>,
 }

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -13,6 +13,7 @@ pub struct BufferLine {
     align: Option<Align>,
     shape_opt: Option<ShapeLine>,
     layout_opt: Option<Vec<LayoutLine>>,
+    line_heights: Option<Vec<f32>>,
     shaping: Shaping,
 }
 
@@ -28,6 +29,7 @@ impl BufferLine {
             align: None,
             shape_opt: None,
             layout_opt: None,
+            line_heights: None,
             shaping,
         }
     }
@@ -155,11 +157,13 @@ impl BufferLine {
     pub fn reset(&mut self) {
         self.shape_opt = None;
         self.layout_opt = None;
+        self.line_heights = None;
     }
 
     /// Reset only layout information
     pub fn reset_layout(&mut self) {
         self.layout_opt = None;
+        self.line_heights = None;
     }
 
     /// Check if shaping and layout information is cleared
@@ -187,6 +191,7 @@ impl BufferLine {
                 self.shaping,
             ));
             self.layout_opt = None;
+            self.line_heights = None;
         }
         self.shape_opt.as_ref().expect("shape not found")
     }
@@ -197,6 +202,8 @@ impl BufferLine {
     }
 
     /// Layout line, will cache results
+    ///
+    /// Ensure that if this buffer line was laid out, you call [`Buffer::update_line_heights`] afterwards
     pub fn layout(
         &mut self,
         font_system: &mut FontSystem,
@@ -208,7 +215,9 @@ impl BufferLine {
             let align = self.align;
             let shape = self.shape(font_system);
             let layout = shape.layout(width, wrap, align);
+            let line_heights = layout.iter().map(|line| line.line_height()).collect();
             self.layout_opt = Some(layout);
+            self.line_heights = Some(line_heights);
         }
         self.layout_opt.as_ref().expect("layout not found")
     }
@@ -235,5 +244,10 @@ impl BufferLine {
     /// Get line layout cache
     pub fn layout_opt(&self) -> &Option<Vec<LayoutLine>> {
         &self.layout_opt
+    }
+
+    /// Get line height cache, maps from [`Self::layout_opt`]
+    pub fn line_heights(&self) -> &Option<Vec<f32>> {
+        &self.line_heights
     }
 }

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -2,10 +2,7 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
-use core::{
-    cmp::{self, Ordering},
-    iter::once,
-};
+use core::{cmp, iter::once};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[cfg(feature = "swash")]
@@ -480,7 +477,6 @@ impl Edit for Editor {
                         _ => break,
                     }
                 }
-                dbg!(current_line, self.buffer.scroll());
                 // let lines = px / self.buffer.metrics().line_height as i32;
                 // match lines.cmp(&0) {
                 //     Ordering::Less => {

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -450,18 +450,16 @@ impl Edit for Editor {
             }
             Action::Vertical(mut px) => {
                 // TODO more efficient
-                let line_heights = self.buffer.line_heights();
-                dbg!(line_heights.len());
                 let cursor = self.buffer.layout_cursor(&self.cursor);
                 let mut current_line = cursor.line as i32;
                 let direction = px.signum();
                 loop {
                     current_line += direction;
-                    if current_line < 0 || current_line >= line_heights.len() as i32 {
+                    if current_line < 0 || current_line >= self.buffer.line_heights().len() as i32 {
                         break;
                     }
 
-                    let current_line_height = line_heights[current_line as usize];
+                    let current_line_height = self.buffer.line_heights()[current_line as usize];
 
                     match direction {
                         -1 => {
@@ -738,7 +736,7 @@ impl Edit for Editor {
             let line_i = run.line_i;
             let line_y = run.line_y;
             let line_top = run.line_top;
-            let line_height = run.line_height();
+            let line_height = run.line_height;
 
             let cursor_glyph_opt = |cursor: &Cursor| -> Option<(usize, f32)> {
                 if cursor.line == line_i {

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -588,6 +588,8 @@ impl Edit for Editor {
                     let old_line = self.buffer.lines.remove(self.cursor.line + 1);
                     self.buffer.lines[self.cursor.line].append(old_line);
                 }
+                // TODO: Delete doesn't redraw without this now
+                self.buffer.set_redraw(true);
             }
             Action::Click { x, y } => {
                 self.select_opt = None;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -63,6 +63,11 @@ pub struct PhysicalGlyph {
 }
 
 impl LayoutGlyph {
+    pub fn line_height(&self) -> f32 {
+        // TODO: should not be hardcoded / should come from Attrs
+        self.font_size * 1.2
+    }
+
     pub fn physical(&self, offset: (f32, f32), scale: f32) -> PhysicalGlyph {
         let x_offset = self.font_size * self.x_offset;
         let y_offset = self.font_size * self.y_offset;
@@ -92,6 +97,16 @@ pub struct LayoutLine {
     pub max_descent: f32,
     /// Glyphs in line
     pub glyphs: Vec<LayoutGlyph>,
+}
+
+impl LayoutLine {
+    pub fn line_height(&self) -> f32 {
+        self.glyphs
+            .iter()
+            .map(|g| g.line_height())
+            .reduce(f32::max)
+            .unwrap_or_default()
+    }
 }
 
 /// Wrapping mode

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -16,6 +16,8 @@ pub struct LayoutGlyph {
     pub end: usize,
     /// Font size of the glyph
     pub font_size: f32,
+    /// Line height
+    pub line_height: f32,
     /// Font id of the glyph
     pub font_id: fontdb::ID,
     /// Font id of the glyph
@@ -63,11 +65,6 @@ pub struct PhysicalGlyph {
 }
 
 impl LayoutGlyph {
-    pub fn line_height(&self) -> f32 {
-        // TODO: should not be hardcoded / should come from Attrs
-        self.font_size * 1.2
-    }
-
     pub fn physical(&self, offset: (f32, f32), scale: f32) -> PhysicalGlyph {
         let x_offset = self.font_size * self.x_offset;
         let y_offset = self.font_size * self.y_offset;
@@ -103,7 +100,7 @@ impl LayoutLine {
     pub fn line_height(&self) -> f32 {
         self.glyphs
             .iter()
-            .map(|g| g.line_height())
+            .map(|g| g.line_height)
             .reduce(f32::max)
             .unwrap_or_default()
     }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -147,6 +147,8 @@ fn shape_fallback(
             metadata: attrs.metadata,
             //TODO: font_size should not be related to shaping
             font_size: attrs.font_size,
+            //TODO: line_height should not be related to shaping
+            line_height: attrs.line_height.height(attrs.font_size),
         });
     }
 
@@ -360,9 +362,14 @@ fn shape_skip(
                     descent,
                     font_id,
                     glyph_id,
+                    //TODO: color should not be related to shaping
                     color_opt: attrs.color_opt,
+                    //TODO: metadata should not be related to shaping
                     metadata: attrs.metadata,
+                    //TODO: font_size should not be related to shaping
                     font_size: attrs.font_size,
+                    //TODO: line_height should not be related to shaping
+                    line_height: attrs.line_height.height(attrs.font_size),
                 }
             }),
     );
@@ -387,6 +394,8 @@ pub struct ShapeGlyph {
     pub metadata: usize,
     // TODO: extract
     pub font_size: f32,
+    // TODO: extract
+    pub line_height: f32,
 }
 
 impl ShapeGlyph {
@@ -403,6 +412,7 @@ impl ShapeGlyph {
             level,
             x_offset: self.x_offset,
             y_offset: self.y_offset,
+            line_height: self.line_height,
             color_opt: self.color_opt,
             metadata: self.metadata,
         }


### PR DESCRIPTION
Current status: Almost done. Working, with some fixes for the editing required.

Fixes #64

Implement specifying multiple font sizes and/or line heights.

https://github.com/pop-os/cosmic-text/assets/38416468/60009d8f-74cf-410f-9c12-9ccff4979110


TODO:

- [x] fix scrolling
- [x] implement `enum LineHeight`
- [x] cache `line_heights()`
- [x] retire `Metrics`
- [x] rebase
- [ ] migrate example editor-orbclient
  - [ ] fix bug empty buffer does not render cursor
  - [ ] fix bug empty buffer has default Attrs
  - [ ] support rescaling font sizes on demand, perhaps via mutable access to spans of Attrs
- [ ] migrate example editor-test
- [ ] migrate example editor-libcosmic (NOTE: does not compile on Windows with pinned version of `iced` (incompatible API))
- [ ] migrate example terminal (NOTE: does not compile on Windows with `termion`, see https://github.com/pop-os/cosmic-text/pull/129)
- [ ] migrate tests
- [ ] migrate benches
- [ ] migrate vi feature
- [ ] fix editor action Vertical
- [ ] fix some editor actions not redrawing
- [x] tidy up
- [ ] docs and PR write-up

Future work:

- Split `Attrs`: `color_opt`, `metadata`, `font_size`, `line_height`
- `Buffer` should have a default `Attrs`
- Convenience method for updating all spans of `Attrs` in a `Buffer`
- Handle start-of-line `Attrs` more carefully

Questions:

- Should the `Hash` impl of `Attrs` include line height?
- Should `Metrics` be restored as a property of `Attrs`, with definition `Metrics { font_size: f32, line_height: LineHeight }`?