### PR TITLE
Add Align::End for end-based alignment

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -120,6 +120,7 @@ pub enum Align {
     Right,
     Center,
     Justified,
+    End,
 }
 
 impl Display for Align {
@@ -129,6 +130,7 @@ impl Display for Align {
             Self::Right => write!(f, "Right"),
             Self::Center => write!(f, "Center"),
             Self::Justified => write!(f, "Justified"),
+            Self::End => write!(f, "End"),
         }
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1001,6 +1001,7 @@ impl ShapeLine {
                 (Align::Right, true) => 0.,
                 (Align::Right, false) => line_width - visual_line.w,
                 (Align::Center, _) => (line_width - visual_line.w) / 2.0,
+                (Align::End, _) => line_width - visual_line.w,
                 (Align::Justified, _) => {
                     // Don't justify the last line in a paragraph.
                     if visual_line.spaces > 0 && index != number_of_visual_lines - 1 {


### PR DESCRIPTION
For use cases that want to reverse the alignment of RTL lines (i.e. `TextAlignment::End` in `piet`), this avoids needing to check the RTL status of every line manually.

This is a breaking change.