### PR TITLE
Small fix for BufferLine::set_align docs

### DIFF
--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -104,7 +104,7 @@ impl BufferLine {
 
     /// Set the text alignment
     ///
-    /// Will reset shape and layout if it differs from current alignment.
+    /// Will reset layout if it differs from current alignment.
     /// Setting to None will use `Align::Right` for RTL lines, and `Align::Left` for LTR lines.
     /// Returns true if the line was reset
     pub fn set_align(&mut self, align: Option<Align>) -> bool {


### PR DESCRIPTION
Remove shape reset from BufferLine::set_align docs since that isn't performed