### PR TITLE
Move hashbrown behind `no_std` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ unicode-linebreak = "0.1.4"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.0"
 rangemap = "1.2.0"
-hashbrown = { version = "0.14.0", default-features = false }
+hashbrown = { version = "0.14.0", optional = true, default-features = false }
 rustc-hash = { version = "1.1.0", default-features = false }
 
 [dependencies.unicode-bidi]
@@ -33,6 +33,7 @@ features = ["hardcoded-data"]
 default = ["std", "swash"]
 no_std = [
   "rustybuzz/libm",
+  "hashbrown",
 ]
 std = [
   "fontdb/memmap",

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -3,10 +3,14 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
-use core::hash::BuildHasherDefault;
 use core::ops::{Deref, DerefMut};
 
-type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasherDefault<rustc_hash::FxHasher>>;
+type BuildHasher = core::hash::BuildHasherDefault<rustc_hash::FxHasher>;
+
+#[cfg(feature = "no_std")]
+type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasher>;
+#[cfg(not(feature = "no_std"))]
+type HashMap<K, V> = std::collections::HashMap<K, V, BuildHasher>;
 
 // re-export fontdb and rustybuzz
 pub use fontdb;


### PR DESCRIPTION
Follow-up to #160 to gate hashbrown behind `no_std` by default

cc @notgull please let me know if this is problematic for some reason