### PR TITLE
Some code organization changes in `ShapeLine::layout`

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -875,17 +875,6 @@ impl ShapeLine {
         align: Option<Align>,
         layout_lines: &mut Vec<LayoutLine>,
     ) {
-        let align = align.unwrap_or({
-            if self.rtl {
-                Align::Right
-            } else {
-                Align::Left
-            }
-        });
-
-        // This is used to create a visual line for empty lines (e.g. lines with only a <CR>)
-        let mut push_line = true;
-
         // For each visual line a list of  (span index,  and range of words in that span)
         // Note that a BiDi visual line could have multiple spans or parts of them
         // let mut vl_range_of_spans = Vec::with_capacity(1);
@@ -1149,6 +1138,14 @@ impl ShapeLine {
         }
 
         // Create the LayoutLines using the ranges inside visual lines
+        let align = align.unwrap_or({
+            if self.rtl {
+                Align::Right
+            } else {
+                Align::Left
+            }
+        });
+
         let start_x = if self.rtl { line_width } else { 0.0 };
 
         let number_of_visual_lines = visual_lines.len();
@@ -1264,10 +1261,10 @@ impl ShapeLine {
                 max_descent: max_descent * font_size,
                 glyphs,
             });
-            push_line = false;
         }
 
-        if push_line {
+        // This is used to create a visual line for empty lines (e.g. lines with only a <CR>)
+        if layout_lines.is_empty() {
             layout_lines.push(LayoutLine {
                 w: 0.0,
                 max_ascent: 0.0,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -916,12 +916,6 @@ impl ShapeLine {
             vl.spaces += number_of_blanks;
         }
 
-        let start_x = if self.rtl { line_width } else { 0.0 };
-        let mut x;
-        let mut y;
-        let mut max_ascent: f32 = 0.;
-        let mut max_descent: f32 = 0.;
-
         // This would keep the maximum number of spans that would fit on a visual line
         // If one span is too large, this variable will hold the range of words inside that span
         // that fits on a line.
@@ -1159,6 +1153,10 @@ impl ShapeLine {
         }
 
         // Create the LayoutLines using the ranges inside visual lines
+        let start_x = if self.rtl { line_width } else { 0.0 };
+        let mut max_ascent: f32 = 0.;
+        let mut max_descent: f32 = 0.;
+
         let number_of_visual_lines = visual_lines.len();
         for (index, visual_line) in visual_lines.iter().enumerate() {
             if visual_line.ranges.is_empty() {
@@ -1166,8 +1164,8 @@ impl ShapeLine {
             }
             let new_order = self.reorder(&visual_line.ranges);
             let mut glyphs = Vec::with_capacity(1);
-            x = start_x;
-            y = 0.;
+            let mut x = start_x;
+            let mut y = 0.;
             max_ascent = 0.;
             max_descent = 0.;
             let alignment_correction = match (align, self.rtl) {
@@ -1357,8 +1355,7 @@ impl ShapeLine {
                     }
                 }
             }
-            let mut glyphs_swap = Vec::new();
-            mem::swap(&mut glyphs, &mut glyphs_swap);
+
             layout_lines.push(LayoutLine {
                 w: if align != Align::Justified {
                     visual_line.w
@@ -1371,7 +1368,7 @@ impl ShapeLine {
                 },
                 max_ascent: max_ascent * font_size,
                 max_descent: max_descent * font_size,
-                glyphs: glyphs_swap,
+                glyphs: mem::take(&mut glyphs),
             });
             push_line = false;
         }


### PR DESCRIPTION
I was reading through this code (to get a better understanding of how alignment is applied and potential avenues for reusing layout work done for width measurement when performing the final layout) and noticed a few things that could be easily de-duplicated or adjusted to improve clarity (IMO).

* Some variables declared at the top of `ShapeLine::layout` weren't used until the second phase which is much farther down, so I moved them down to be at the start of that phase.
* Replaced the `push_line` `bool` with checking `layout_lines.is_empty()` which is effectively equivalent.
* Some variables defined outside the loop over `visual_lines` were reset with each loop iteration, so I moved their definitions down into the loop.
* Added a separate `justification_expansion` instead of reusing the `alignment_correction` variable (which just shifts the line in all other modes, but was used to hold how much each space should be expanded when justifying). This is more clear to the reader and avoids several later checks of whether the alignment is `Align::Justified` in spots where `alignment_correction` is used. _(I may have gone overboard with the other changes but I think at least this one is pretty useful)_
* I was able to factor out the common code during iterating visual line ranges for LTR/RTL text into a `process_range` closure as well as combine several cases of iterating over glyphs during this.
* Removed unnecessary `mem::swap(&mut glyphs, &mut glyphs_swap); ` (`glyphs` is not used later and can just be directly moved out of)

None of these changes should affect the behavior (If I didn't make any mistakes!).