### PR TITLE
enable std feature with fontconfig feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ std = [
 vi = ["syntect"]
 wasm-web = ["sys-locale?/js"]
 warn_on_missing_glyphs = []
-fontconfig = ["fontdb/fontconfig"]
+fontconfig = ["fontdb/fontconfig", "std"]
 
 [[bench]]
 name = "layout"


### PR DESCRIPTION
Enables the `std` feature with the `fontconfig` feature introduced in #171.  `fontdb` uses the standard library when their `fontconfig` feature is enabled.
https://github.com/RazrFalcon/fontdb/blob/70633ac70b8c7b264332f68e7ad4f43961707bc3/Cargo.toml#L32-L37