### PR TITLE
enable fontconfig feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default-features = false
 features = ["hardcoded-data"]
 
 [features]
-default = ["std", "swash"]
+default = ["std", "swash", "fontconfig"]
 no_std = [
   "rustybuzz/libm",
   "hashbrown",


### PR DESCRIPTION
Resolves #167.  See the discussion in RazrFalcon/fontdb#56 (TLDR: this isn't a perfect solution because fontdb's "`fontconfig` support isn't perfect... a proper Linux solution would require using `fontconfig` directly").