### PR TITLE
Add IME support, extended actions, customize appearance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ modit = { version = "0.1.4", optional = true }
 rangemap = "1.4.0"
 rustc-hash = { version = "1.1.0", default-features = false }
 rustybuzz = { version = "0.12.0", default-features = false, features = ["libm"] }
+itertools = "0.11.0"
 self_cell = "1.0.1"
 swash = { version = "0.1.12", optional = true }
 syntect = { version = "5.1.0", optional = true }

--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -17,6 +17,7 @@ fn redraw(
     let font_color = Color::rgb(0xFF, 0xFF, 0xFF);
     let cursor_color = Color::rgb(0xFF, 0xFF, 0xFF);
     let selection_color = Color::rgba(0xFF, 0xFF, 0xFF, 0x33);
+    let selected_text_color = Color::rgb(0xF0, 0xF0, 0xFF);
 
     editor.shape_as_needed(true);
     if editor.redraw() {
@@ -29,6 +30,7 @@ fn redraw(
             font_color,
             cursor_color,
             selection_color,
+            selected_text_color,
             |x, y, w, h, color| {
                 window.rect(x, y, w, h, orbclient::Color { data: color.0 });
             },

--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -116,7 +116,10 @@ fn main() {
             // Test delete of EGC
             {
                 let cursor = editor.cursor();
-                editor.action(Action::Motion(Motion::Previous));
+                editor.action(Action::Motion {
+                    motion: Motion::Previous,
+                    select: false,
+                });
                 editor.action(Action::Delete);
                 for c in grapheme.chars() {
                     editor.action(Action::Insert(c));
@@ -140,7 +143,10 @@ fn main() {
         {
             let cursor = editor.cursor();
             editor.action(Action::Enter);
-            editor.action(Action::Motion(Motion::Previous));
+            editor.action(Action::Motion {
+                motion: Motion::Previous,
+                select: false,
+            });
             editor.action(Action::Delete);
             assert_eq!(cursor, editor.cursor());
         }

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -63,6 +63,7 @@ fn main() {
     }
 
     let mut ctrl_pressed = false;
+    let mut shift_pressed = false;
     let mut mouse_x = 0.0;
     let mut mouse_y = 0.0;
     let mut mouse_left = ElementState::Released;
@@ -175,7 +176,8 @@ fn main() {
                             surface_buffer.present().unwrap();
                         }
                         WindowEvent::ModifiersChanged(modifiers) => {
-                            ctrl_pressed = modifiers.state().control_key()
+                            ctrl_pressed = modifiers.state().control_key();
+                            shift_pressed = modifiers.state().shift_key();
                         }
                         WindowEvent::KeyboardInput { event, .. } => {
                             let KeyEvent {
@@ -185,28 +187,46 @@ fn main() {
                             if state.is_pressed() {
                                 match logical_key {
                                     Key::Named(NamedKey::ArrowLeft) => {
-                                        editor.action(Action::Motion(Motion::Left))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Left,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::ArrowRight) => {
-                                        editor.action(Action::Motion(Motion::Right))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Right,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::ArrowUp) => {
-                                        editor.action(Action::Motion(Motion::Up))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Up,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::ArrowDown) => {
-                                        editor.action(Action::Motion(Motion::Down))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Down,
+                                            select: shift_pressed,
+                                        })
                                     }
-                                    Key::Named(NamedKey::Home) => {
-                                        editor.action(Action::Motion(Motion::Home))
-                                    }
-                                    Key::Named(NamedKey::End) => {
-                                        editor.action(Action::Motion(Motion::End))
-                                    }
-                                    Key::Named(NamedKey::PageUp) => {
-                                        editor.action(Action::Motion(Motion::PageUp))
-                                    }
+                                    Key::Named(NamedKey::Home) => editor.action(Action::Motion {
+                                        motion: Motion::Home,
+                                        select: shift_pressed,
+                                    }),
+                                    Key::Named(NamedKey::End) => editor.action(Action::Motion {
+                                        motion: Motion::End,
+                                        select: shift_pressed,
+                                    }),
+                                    Key::Named(NamedKey::PageUp) => editor.action(Action::Motion {
+                                        motion: Motion::PageUp,
+                                        select: shift_pressed,
+                                    }),
                                     Key::Named(NamedKey::PageDown) => {
-                                        editor.action(Action::Motion(Motion::PageDown))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::PageDown,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::Escape) => editor.action(Action::Escape),
                                     Key::Named(NamedKey::Enter) => editor.action(Action::Enter),
@@ -321,6 +341,7 @@ fn main() {
                                     editor.action(Action::Click {
                                         x: mouse_x as i32,
                                         y: mouse_y as i32,
+                                        select: shift_pressed,
                                     });
                                     window.request_redraw();
                                 }

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -188,13 +188,21 @@ fn main() {
                                 match logical_key {
                                     Key::Named(NamedKey::ArrowLeft) => {
                                         editor.action(Action::Motion {
-                                            motion: Motion::Left,
+                                            motion: if ctrl_pressed {
+                                                Motion::PreviousWord
+                                            } else {
+                                                Motion::Left
+                                            },
                                             select: shift_pressed,
                                         })
                                     }
                                     Key::Named(NamedKey::ArrowRight) => {
                                         editor.action(Action::Motion {
-                                            motion: Motion::Right,
+                                            motion: if ctrl_pressed {
+                                                Motion::NextWord
+                                            } else {
+                                                Motion::Right
+                                            },
                                             select: shift_pressed,
                                         })
                                     }

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -229,11 +229,19 @@ fn main() {
                                         })
                                     }
                                     Key::Named(NamedKey::Home) => editor.action(Action::Motion {
-                                        motion: Motion::Home,
+                                        motion: if ctrl_pressed {
+                                            Motion::DocumentStart
+                                        } else {
+                                            Motion::Home
+                                        },
                                         select: shift_pressed,
                                     }),
                                     Key::Named(NamedKey::End) => editor.action(Action::Motion {
-                                        motion: Motion::End,
+                                        motion: if ctrl_pressed {
+                                            Motion::DocumentEnd
+                                        } else {
+                                            Motion::End
+                                        },
                                         select: shift_pressed,
                                     }),
                                     Key::Named(NamedKey::PageUp) => editor.action(Action::Motion {
@@ -249,9 +257,19 @@ fn main() {
                                     Key::Named(NamedKey::Escape) => editor.action(Action::Escape),
                                     Key::Named(NamedKey::Enter) => editor.action(Action::Enter),
                                     Key::Named(NamedKey::Backspace) => {
-                                        editor.action(Action::Backspace)
+                                        editor.action(if ctrl_pressed {
+                                            Action::DeleteStartOfWord
+                                        } else {
+                                            Action::Backspace
+                                        })
                                     }
-                                    Key::Named(NamedKey::Delete) => editor.action(Action::Delete),
+                                    Key::Named(NamedKey::Delete) => {
+                                        editor.action(if ctrl_pressed {
+                                            Action::DeleteEndOfWord
+                                        } else {
+                                            Action::Delete
+                                        })
+                                    }
                                     Key::Named(key) => {
                                         if let Some(text) = key.to_text() {
                                             for c in text.chars() {
@@ -292,6 +310,9 @@ fn main() {
                                                             )
                                                         });
                                                     }
+                                                }
+                                                "a" => {
+                                                    editor.action(Action::SelectAll);
                                                 }
                                                 _ => {}
                                             }

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -121,6 +121,7 @@ fn main() {
     editor.with_buffer_mut(|buffer| set_buffer_text(buffer));
 
     let mut ctrl_pressed = false;
+    let mut shift_pressed = false;
     let mut mouse_x = 0.0;
     let mut mouse_y = 0.0;
     let mut mouse_left = ElementState::Released;
@@ -209,7 +210,8 @@ fn main() {
                             surface_buffer.present().unwrap();
                         }
                         WindowEvent::ModifiersChanged(modifiers) => {
-                            ctrl_pressed = modifiers.state().control_key()
+                            ctrl_pressed = modifiers.state().control_key();
+                            shift_pressed = modifiers.state().shift_key();
                         }
                         WindowEvent::KeyboardInput { event, .. } => {
                             let KeyEvent {
@@ -219,28 +221,46 @@ fn main() {
                             if state.is_pressed() {
                                 match logical_key {
                                     Key::Named(NamedKey::ArrowLeft) => {
-                                        editor.action(Action::Motion(Motion::Left))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Left,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::ArrowRight) => {
-                                        editor.action(Action::Motion(Motion::Right))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Right,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::ArrowUp) => {
-                                        editor.action(Action::Motion(Motion::Up))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Up,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::ArrowDown) => {
-                                        editor.action(Action::Motion(Motion::Down))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::Down,
+                                            select: shift_pressed,
+                                        })
                                     }
-                                    Key::Named(NamedKey::Home) => {
-                                        editor.action(Action::Motion(Motion::Home))
-                                    }
-                                    Key::Named(NamedKey::End) => {
-                                        editor.action(Action::Motion(Motion::End))
-                                    }
-                                    Key::Named(NamedKey::PageUp) => {
-                                        editor.action(Action::Motion(Motion::PageUp))
-                                    }
+                                    Key::Named(NamedKey::Home) => editor.action(Action::Motion {
+                                        motion: Motion::Home,
+                                        select: shift_pressed,
+                                    }),
+                                    Key::Named(NamedKey::End) => editor.action(Action::Motion {
+                                        motion: Motion::End,
+                                        select: shift_pressed,
+                                    }),
+                                    Key::Named(NamedKey::PageUp) => editor.action(Action::Motion {
+                                        motion: Motion::PageUp,
+                                        select: shift_pressed,
+                                    }),
                                     Key::Named(NamedKey::PageDown) => {
-                                        editor.action(Action::Motion(Motion::PageDown))
+                                        editor.action(Action::Motion {
+                                            motion: Motion::PageDown,
+                                            select: shift_pressed,
+                                        })
                                     }
                                     Key::Named(NamedKey::Escape) => editor.action(Action::Escape),
                                     Key::Named(NamedKey::Enter) => editor.action(Action::Enter),
@@ -305,6 +325,7 @@ fn main() {
                                     editor.action(Action::Click {
                                         x: mouse_x /*- line_x*/ as i32,
                                         y: mouse_y as i32,
+                                        select: shift_pressed,
                                     });
                                     window.request_redraw();
                                 }

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -130,6 +130,7 @@ fn main() {
     let font_color = Color::rgb(0xFF, 0xFF, 0xFF);
     let cursor_color = Color::rgb(0xFF, 0xFF, 0xFF);
     let selection_color = Color::rgba(0xFF, 0xFF, 0xFF, 0x33);
+    let selected_text_color = Color::rgb(0xA0, 0xA0, 0xFF);
 
     event_loop
         .run(|event, elwt| {
@@ -185,6 +186,7 @@ fn main() {
                                 font_color,
                                 cursor_color,
                                 selection_color,
+                                selected_text_color,
                                 |x, y, w, h, color| {
                                     // Note: due to softbuffer and tiny_skia having incompatible internal color representations we swap
                                     // the red and blue channels here

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -112,6 +112,7 @@ pub struct Attrs<'a> {
     pub weight: Weight,
     pub metadata: usize,
     pub cache_key_flags: CacheKeyFlags,
+    pub is_preedit: bool,
 }
 
 impl<'a> Attrs<'a> {
@@ -127,6 +128,7 @@ impl<'a> Attrs<'a> {
             weight: Weight::NORMAL,
             metadata: 0,
             cache_key_flags: CacheKeyFlags::empty(),
+            is_preedit: false,
         }
     }
 
@@ -169,6 +171,12 @@ impl<'a> Attrs<'a> {
     /// Set [`CacheKeyFlags`]
     pub fn cache_key_flags(mut self, cache_key_flags: CacheKeyFlags) -> Self {
         self.cache_key_flags = cache_key_flags;
+        self
+    }
+
+    /// Set preedit
+    pub fn preedit(mut self, is_preedit: bool) -> Self {
+        self.is_preedit = is_preedit;
         self
     }
 
@@ -219,6 +227,7 @@ pub struct AttrsOwned {
     pub weight: Weight,
     pub metadata: usize,
     pub cache_key_flags: CacheKeyFlags,
+    pub is_preedit: bool,
 }
 
 impl AttrsOwned {
@@ -231,6 +240,7 @@ impl AttrsOwned {
             weight: attrs.weight,
             metadata: attrs.metadata,
             cache_key_flags: attrs.cache_key_flags,
+            is_preedit: attrs.is_preedit,
         }
     }
 
@@ -243,6 +253,7 @@ impl AttrsOwned {
             weight: self.weight,
             metadata: self.metadata,
             cache_key_flags: self.cache_key_flags,
+            is_preedit: self.is_preedit,
         }
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1059,6 +1059,16 @@ impl Buffer {
                 cursor.index = self.lines.get(cursor.line)?.text().len();
                 cursor_x_opt = None;
             }
+            Motion::DocumentStart => {
+                cursor.line = 0;
+                cursor.index = 0;
+                cursor_x_opt = None;
+            }
+            Motion::DocumentEnd => {
+                cursor.line = self.lines.len() - 1;
+                cursor.index = self.lines.get(cursor.line)?.text().len();
+                cursor_x_opt = None;
+            }
             Motion::PageUp => {
                 (cursor, cursor_x_opt) = self.cursor_motion(
                     font_system,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 use core::{cmp, fmt};
+use itertools::Itertools;
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
@@ -715,6 +716,14 @@ impl Buffer {
         self.scroll = Scroll::default();
 
         self.shape_until_scroll(font_system, false);
+    }
+
+    /// Returns text of the buffer, excluding preedit (if any)
+    pub fn text_without_preedit(&self) -> String {
+        self.lines
+            .iter()
+            .map(|line| line.text_without_preedit())
+            .join("\n")
     }
 
     /// True if a redraw is needed

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -109,6 +109,10 @@ pub enum Motion {
     ParagraphStart,
     /// Move cursor to end of paragraph
     ParagraphEnd,
+    /// Move cursor to start of document
+    DocumentStart,
+    /// Move cursor to end of document
+    DocumentEnd,
     /// Move cursor up one page
     PageUp,
     /// Move cursor down one page

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -5,14 +5,14 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{cmp, iter::once};
+use core::{cmp, iter::once, ops::Range};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[cfg(feature = "swash")]
 use crate::Color;
 use crate::{
     Action, Attrs, AttrsList, BorrowedWithFontSystem, BufferLine, BufferRef, Change, ChangeItem,
-    Cursor, Edit, FontSystem, Selection, Shaping,
+    Cursor, Edit, FontSystem, LayoutRun, Selection, Shaping,
 };
 
 /// A wrapper of [`Buffer`] for easy editing
@@ -26,6 +26,72 @@ pub struct Editor<'buffer> {
     auto_indent: bool,
     tab_width: u16,
     change: Option<Change>,
+}
+
+fn cursor_glyph_opt(cursor: &Cursor, run: &LayoutRun) -> Option<(usize, f32)> {
+    if cursor.line == run.line_i {
+        for (glyph_i, glyph) in run.glyphs.iter().enumerate() {
+            if cursor.index == glyph.start {
+                return Some((glyph_i, 0.0));
+            } else if cursor.index > glyph.start && cursor.index < glyph.end {
+                // Guess x offset based on characters
+                let mut before = 0;
+                let mut total = 0;
+
+                let cluster = &run.text[glyph.start..glyph.end];
+                for (i, _) in cluster.grapheme_indices(true) {
+                    if glyph.start + i < cursor.index {
+                        before += 1;
+                    }
+                    total += 1;
+                }
+
+                let offset = glyph.w * (before as f32) / (total as f32);
+                return Some((glyph_i, offset));
+            }
+        }
+        match run.glyphs.last() {
+            Some(glyph) => {
+                if cursor.index == glyph.end {
+                    return Some((run.glyphs.len(), 0.0));
+                }
+            }
+            None => {
+                return Some((0, 0.0));
+            }
+        }
+    }
+    None
+}
+
+fn cursor_position(cursor: &Cursor, run: &LayoutRun) -> Option<(i32, i32)> {
+    let (cursor_glyph, cursor_glyph_offset) = cursor_glyph_opt(cursor, run)?;
+    let x = match run.glyphs.get(cursor_glyph) {
+        Some(glyph) => {
+            // Start of detected glyph
+            if glyph.level.is_rtl() {
+                (glyph.x + glyph.w - cursor_glyph_offset) as i32
+            } else {
+                (glyph.x + cursor_glyph_offset) as i32
+            }
+        }
+        None => match run.glyphs.last() {
+            Some(glyph) => {
+                // End of last glyph
+                if glyph.level.is_rtl() {
+                    glyph.x as i32
+                } else {
+                    (glyph.x + glyph.w) as i32
+                }
+            }
+            None => {
+                // Start of empty line
+                0
+            }
+        },
+    };
+
+    Some((x, run.line_top as i32))
 }
 
 impl<'buffer> Editor<'buffer> {
@@ -62,42 +128,6 @@ impl<'buffer> Editor<'buffer> {
                 let line_i = run.line_i;
                 let line_y = run.line_y;
                 let line_top = run.line_top;
-
-                let cursor_glyph_opt = |cursor: &Cursor| -> Option<(usize, f32)> {
-                    if cursor.line == line_i {
-                        for (glyph_i, glyph) in run.glyphs.iter().enumerate() {
-                            if cursor.index == glyph.start {
-                                return Some((glyph_i, 0.0));
-                            } else if cursor.index > glyph.start && cursor.index < glyph.end {
-                                // Guess x offset based on characters
-                                let mut before = 0;
-                                let mut total = 0;
-
-                                let cluster = &run.text[glyph.start..glyph.end];
-                                for (i, _) in cluster.grapheme_indices(true) {
-                                    if glyph.start + i < cursor.index {
-                                        before += 1;
-                                    }
-                                    total += 1;
-                                }
-
-                                let offset = glyph.w * (before as f32) / (total as f32);
-                                return Some((glyph_i, offset));
-                            }
-                        }
-                        match run.glyphs.last() {
-                            Some(glyph) => {
-                                if cursor.index == glyph.end {
-                                    return Some((run.glyphs.len(), 0.0));
-                                }
-                            }
-                            None => {
-                                return Some((0, 0.0));
-                            }
-                        }
-                    }
-                    None
-                };
 
                 // Highlight selection
                 if let Some((start, end)) = self.selection_bounds() {
@@ -161,33 +191,8 @@ impl<'buffer> Editor<'buffer> {
                 }
 
                 // Draw cursor
-                if let Some((cursor_glyph, cursor_glyph_offset)) = cursor_glyph_opt(&self.cursor) {
-                    let x = match run.glyphs.get(cursor_glyph) {
-                        Some(glyph) => {
-                            // Start of detected glyph
-                            if glyph.level.is_rtl() {
-                                (glyph.x + glyph.w - cursor_glyph_offset) as i32
-                            } else {
-                                (glyph.x + cursor_glyph_offset) as i32
-                            }
-                        }
-                        None => match run.glyphs.last() {
-                            Some(glyph) => {
-                                // End of last glyph
-                                if glyph.level.is_rtl() {
-                                    glyph.x as i32
-                                } else {
-                                    (glyph.x + glyph.w) as i32
-                                }
-                            }
-                            None => {
-                                // Start of empty line
-                                0
-                            }
-                        },
-                    };
-
-                    f(x, line_top as i32, 1, line_height as u32, cursor_color);
+                if let Some((x, y)) = cursor_position(&self.cursor, &run) {
+                    f(x, y, 1, line_height as u32, cursor_color);
                 }
 
                 for glyph in run.glyphs.iter() {
@@ -541,6 +546,18 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
         self.change.take()
     }
 
+    fn preedit_range(&self) -> Option<Range<usize>> {
+        self.with_buffer(|buffer| buffer.lines[self.cursor.line].preedit_range())
+    }
+
+    fn preedit_text(&self) -> Option<String> {
+        self.with_buffer(|buffer| {
+            buffer.lines[self.cursor.line]
+                .preedit_text()
+                .map(Into::into)
+        })
+    }
+
     fn action(&mut self, font_system: &mut FontSystem, action: Action) {
         let old_cursor = self.cursor;
 
@@ -844,6 +861,57 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                     buffer.set_scroll(scroll);
                 });
             }
+            Action::SetPreedit {
+                preedit,
+                cursor,
+                attrs,
+            } => {
+                self.selection = Selection::None;
+                let mut self_cursor = self.cursor;
+
+                // Remove old preedit, if any
+                self.with_buffer_mut(|buffer| {
+                    let line: &mut BufferLine = &mut buffer.lines[self_cursor.line];
+                    if let Some(range) = line.preedit_range() {
+                        let end = line.split_off(range.end);
+                        line.split_off(range.start);
+                        line.append(end);
+                        self_cursor.index = range.start;
+                    }
+                });
+                self.cursor = self_cursor;
+
+                if !preedit.is_empty() {
+                    let new_attrs = if let Some(attrs) = attrs {
+                        AttrsList::new(attrs.as_attrs().preedit(true))
+                    } else {
+                        self.with_buffer(|buffer| {
+                            let attrs_at_cursor = buffer.lines[self_cursor.line]
+                                .attrs_list()
+                                .get_span(self_cursor.index);
+                            AttrsList::new(
+                                attrs_at_cursor
+                                    .preedit(true)
+                                    .color(Color::rgb(128, 128, 128)),
+                            )
+                        })
+                    };
+                    self.insert_string(&preedit, Some(new_attrs));
+                    if let Some((start, end)) = cursor {
+                        let end_delta = preedit.len().saturating_sub(end);
+                        self.cursor.index = self.cursor.index.saturating_sub(end_delta);
+                        if start != end {
+                            let start_delta = preedit.len().saturating_sub(start);
+                            let mut select = self.cursor;
+                            select.index = select.index.saturating_sub(start_delta);
+                            self.selection = Selection::Normal(select);
+                        }
+                    } else {
+                        // TODO: hide cursor
+                    }
+                }
+                self.set_redraw(true);
+            }
         }
 
         if old_cursor != self.cursor {
@@ -866,6 +934,14 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
             }
             */
         }
+    }
+
+    fn cursor_position(&self) -> Option<(i32, i32)> {
+        self.with_buffer(|buffer| {
+            buffer
+                .layout_runs()
+                .find_map(|run| cursor_position(&self.cursor, &run))
+        })
     }
 }
 

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -648,6 +648,22 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                 }
                 self.selection = Selection::None;
             }
+            Action::SelectAll => {
+                self.action(
+                    font_system,
+                    Action::Motion {
+                        motion: Motion::DocumentStart,
+                        select: false,
+                    },
+                );
+                self.action(
+                    font_system,
+                    Action::Motion {
+                        motion: Motion::DocumentEnd,
+                        select: true,
+                    },
+                );
+            }
             Action::Insert(character) => {
                 if character.is_control() && !['\t', '\n', '\u{92}'].contains(&character) {
                     // Filter out special chars (except for tab), use Action instead
@@ -714,6 +730,20 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                     }
                 }
             }
+            Action::DeleteStartOfWord => {
+                if self.delete_selection() {
+                    // Deleted selection
+                } else {
+                    self.action(
+                        font_system,
+                        Action::Motion {
+                            motion: Motion::PreviousWord,
+                            select: true,
+                        },
+                    );
+                    self.delete_selection();
+                }
+            }
             Action::Delete => {
                 if self.delete_selection() {
                     // Deleted selection
@@ -747,6 +777,20 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                         self.cursor = start;
                         self.delete_range(start, end);
                     }
+                }
+            }
+            Action::DeleteEndOfWord => {
+                if self.delete_selection() {
+                    // Deleted selection
+                } else {
+                    self.action(
+                        font_system,
+                        Action::Motion {
+                            motion: Motion::NextWord,
+                            select: true,
+                        },
+                    );
+                    self.delete_selection();
                 }
             }
             Action::Indent => {

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -12,7 +12,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::Color;
 use crate::{
     Action, Attrs, AttrsList, BorrowedWithFontSystem, BufferLine, BufferRef, Change, ChangeItem,
-    Cursor, Edit, FontSystem, LayoutRun, Selection, Shaping,
+    Cursor, Edit, FontSystem, LayoutRun, Motion, Selection, Shaping,
 };
 
 /// A wrapper of [`Buffer`] for easy editing
@@ -593,8 +593,46 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
         let old_cursor = self.cursor;
 
         match action {
-            Action::Motion(motion) => {
+            Action::Motion { motion, select } => {
                 let cursor = self.cursor;
+                if select {
+                    if self.selection == Selection::None {
+                        self.selection = Selection::Normal(self.cursor);
+                    }
+                } else if let Some((start, end)) = self.selection_bounds() {
+                    if start.line != end.line || start.index != end.index {
+                        let new_cursor = match motion {
+                            // These actions have special behavior when there is an active selection.
+                            Motion::Previous => Some(start),
+                            Motion::Next => Some(end),
+                            Motion::Left => self
+                                .with_buffer_mut(|buffer| {
+                                    buffer
+                                        .line_shape(font_system, cursor.line)
+                                        .map(|shape| shape.rtl)
+                                })
+                                .map(|rtl| if rtl { end } else { start }),
+                            Motion::Right => self
+                                .with_buffer_mut(|buffer| {
+                                    buffer
+                                        .line_shape(font_system, cursor.line)
+                                        .map(|shape| shape.rtl)
+                                })
+                                .map(|rtl| if rtl { start } else { end }),
+                            _ => None,
+                        };
+                        if let Some(new_cursor) = new_cursor {
+                            self.cursor = new_cursor;
+                            self.cursor_x_opt = None;
+                            self.cursor_moved = true;
+                            self.selection = Selection::None;
+                            self.set_redraw(true);
+                            return;
+                        }
+                    }
+                    self.selection = Selection::None;
+                }
+
                 let cursor_x_opt = self.cursor_x_opt;
                 if let Some((new_cursor, new_cursor_x_opt)) = self.with_buffer_mut(|buffer| {
                     buffer.cursor_motion(font_system, cursor, cursor_x_opt, motion)
@@ -835,8 +873,14 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                     self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                 }
             }
-            Action::Click { x, y } => {
-                self.set_selection(Selection::None);
+            Action::Click { x, y, select } => {
+                if select {
+                    if self.selection == Selection::None {
+                        self.selection = Selection::Normal(self.cursor);
+                    }
+                } else {
+                    self.selection = Selection::None;
+                }
 
                 if let Some(new_cursor) = self.with_buffer(|buffer| buffer.hit(x as f32, y as f32))
                 {

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -31,14 +31,20 @@ pub enum Action {
     },
     /// Escape, clears selection
     Escape,
+    /// Select text from start to end
+    SelectAll,
     /// Insert character at cursor
     Insert(char),
     /// Create new line
     Enter,
     /// Delete text behind cursor
     Backspace,
+    /// Delete text behind cursor to next word boundary
+    DeleteStartOfWord,
     /// Delete text in front of cursor
     Delete,
+    /// Delete text in front of cursor to next word boundary
+    DeleteEndOfWord,
     // Indent text (typically Tab)
     Indent,
     // Unindent text (typically Shift+Tab)

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -209,8 +209,32 @@ pub trait Edit<'buffer> {
     /// Get the current cursor
     fn cursor(&self) -> Cursor;
 
+    /// Hide or show the cursor
+    ///
+    /// This should be used to hide the cursor, for example,
+    /// when the editor is unfocused, when the text is not editable,
+    /// or to implement cursor blinking.
+    ///
+    /// Note that even after `set_cursor_hidden(false)`, the editor may
+    /// choose to hide the cursor based on internal state, for example,
+    /// when there is a selection or when there is a preedit without a cursor.
+    fn set_cursor_hidden(&mut self, hidden: bool);
+
     /// Set the current cursor
     fn set_cursor(&mut self, cursor: Cursor);
+
+    /// Returns true if some text is selected
+    fn has_selection(&self) -> bool {
+        match self.selection() {
+            Selection::None => false,
+            Selection::Normal(selection) => {
+                let cursor = self.cursor();
+                selection.line != cursor.line || selection.index != cursor.index
+            }
+            Selection::Line(selection) => selection.line != self.cursor().line,
+            Selection::Word(_) => true,
+        }
+    }
 
     /// Get the current selection position
     fn selection(&self) -> Selection;

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -25,7 +25,10 @@ mod vi;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Action {
     /// Move the cursor with some motion
-    Motion(Motion),
+    Motion {
+        motion: Motion,
+        select: bool,
+    },
     /// Escape, clears selection
     Escape,
     /// Insert character at cursor
@@ -44,6 +47,7 @@ pub enum Action {
     Click {
         x: i32,
         y: i32,
+        select: bool,
     },
     /// Mouse double click at specified position
     DoubleClick {

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -234,6 +234,10 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for SyntaxEditor<'syntax_system, 'bu
         self.editor.selection()
     }
 
+    fn set_cursor_hidden(&mut self, hidden: bool) {
+        self.editor.set_cursor_hidden(hidden);
+    }
+
     fn set_selection(&mut self, selection: Selection) {
         self.editor.set_selection(selection);
     }

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -208,6 +208,7 @@ impl<'syntax_system, 'buffer> SyntaxEditor<'syntax_system, 'buffer> {
             self.foreground_color(),
             self.cursor_color(),
             self.selection_color(),
+            self.foreground_color(),
             f,
         );
     }

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -272,6 +272,9 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for SyntaxEditor<'syntax_system, 'bu
                 }
 
                 let line = &mut buffer.lines[line_i];
+                if line.preedit_range().is_some() {
+                    continue;
+                }
                 if line.metadata().is_some() && line_i < self.syntax_cache.len() {
                     //TODO: duplicated code!
                     if line_i >= scroll.line && total_layout < scroll_end {
@@ -399,12 +402,24 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for SyntaxEditor<'syntax_system, 'bu
         self.editor.start_change();
     }
 
+    fn preedit_range(&self) -> Option<core::ops::Range<usize>> {
+        self.editor.preedit_range()
+    }
+
+    fn preedit_text(&self) -> Option<String> {
+        self.editor.preedit_text()
+    }
+
     fn finish_change(&mut self) -> Option<Change> {
         self.editor.finish_change()
     }
 
     fn action(&mut self, font_system: &mut FontSystem, action: Action) {
         self.editor.action(font_system, action);
+    }
+
+    fn cursor_position(&self) -> Option<(i32, i32)> {
+        self.editor.cursor_position()
     }
 }
 

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -1169,6 +1169,10 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for ViEditor<'syntax_system, 'buffer
     fn cursor_position(&self) -> Option<(i32, i32)> {
         self.editor.cursor_position()
     }
+
+    fn set_cursor_hidden(&mut self, hidden: bool) {
+        self.editor.set_cursor_hidden(hidden);
+    }
 }
 
 impl<'font_system, 'syntax_system, 'buffer>

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -1157,6 +1157,18 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for ViEditor<'syntax_system, 'buffer
             editor.action(font_system, action);
         });
     }
+
+    fn preedit_range(&self) -> Option<core::ops::Range<usize>> {
+        self.editor.preedit_range()
+    }
+
+    fn preedit_text(&self) -> Option<String> {
+        self.editor.preedit_text()
+    }
+
+    fn cursor_position(&self) -> Option<(i32, i32)> {
+        self.editor.cursor_position()
+    }
 }
 
 impl<'font_system, 'syntax_system, 'buffer>


### PR DESCRIPTION
I was trying to implement a text input that works the same way as a native text input on desktop platforms. I would like to contribute the changes I had to make to `cosmic-text`.

# IME support

Input method editors are required for convenient text input in some languages, so its support is essential for good user experience. While it's possible to implement some of the following changes in a wrapper around `cosmic-text`, I think it would be better to incorporate them here and provide this support to all users.

1. Added `SetPreedit` action that inserts text with a special `is_preedit` flag in the attributes and clears any previous preedit. This is the most straightforward way to show a preedit inline, so that it works naturally with shaping and word wrapping. The downside is that the buffer's text is not the same as the document text anymore. For example, if the user wants to retrieve the text from the buffer, they should delete the part corresponding to the preedit (or clear the preedit). To help with this, I added `Buffer::text_without_preedit()` and `BufferLine::text_without_preedit()`.
2. Added `Edit::cursor_position()` method to retrieve the coordinates of the visual cursor. This is required to set the IME position, so that the input method window is displayed close to the cursor. The current implementation simply reuses the `Editor::draw()` code (moved out to a function). This can probably be done more efficiently.

There are also some aspects that I decided to implement outside of `cosmic-text` for now:

1. Handling mouse events while there is an active preedit. There are some applications where it's possible to set the IME cursor position by clicking inside the preedit area, but in the most cases the applications just ignore mouse clicks and drags initiated over the preedit area. However, if you click outside of the preedit, the current preedit is usually just committed, and the IME state is reset. This reset action is a problem because it means we cannot simply implement it in the editor's action handler.  There has to be a way for the editor to communicate to the host application that an IME reset is needed.  There are ways to modify the API for that, but I decided that it's out of scope of this PR.
2. Drawing underline of the preedit, which seems to be the most common way to represent it visually. It's possible to add support for underline styling to `Buffer` (for example, by integrating with `line-straddler`), at which point it would be pretty easy to change the default preedit attributes to underline instead of the current color change.

# Hiding text cursor

1. Cursor is now hidden when there is a selection.
2. Cursor is now hidden when there is an IME preedit that specifies that there should be no cursor.
3. Added `Edit::set_cursor_hidden()` to hide cursor manually, which can be used to implement cursor blinking, and to hide cursor when the input is unfocused or read only.

While I generally prefer "positive" boolean flags (e.g. `set_cursor_visible()` would generally be better), in this case the logic looks simpler when we use the `hidden` flag: `cursor_hidden = has_selection || has_preedit_without_cursor || set_cursor_hidden`.

# Extended mouse and keyboard actions

I was aiming to implement all standard keyboard shortcuts and mouse actions that are usually present on desktop systems.

1. Added missing actions: `DocumentStart`, `DocumentEnd`, `SelectAll`, `DeleteStartOfWord`, `DeleteEndOfWord`, `SelectWord`, `SelectParagraph`.
2. Added `select` flag to `Edit::action()` to implement hotkeys with `Shift` modifier (e.g. `Shift + ArrowRight` to create or extend the selection) and fix hotkeys without `Shift` (e.g. `ArrowRight` previously didn't clear existing selection). I think this is the simplest way to implement it currently. It's not ideal because this flag only makes sense for some actions, but refactoring this API would be more dirsuptive.
3. Fixed `Previous` and `Next` behavior when there is a selection. They now clear selection and put the cursor to the start and end of the selection, respectively.
4. Fixed `NextWord` action to go to the end of line if there are no more word boundaries. Previously, it could get stuck and not move forward at all in some cases.

All new actions can be tested in the `editor-orbclient` example (I chose it because it already had some keyboard modifiers support, unlike the other examples).

# More styling options

1. Added an option to change the selection color (it was previously hardcoded).
2. Added an option to set the selected text color. This is often needed to replicate the appearance of native widgets.