### PR TITLE
Small `Editor` fixes

### DIFF
--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -235,8 +235,12 @@ impl Edit for Editor {
         let after_len = after.text().len();
 
         // Collect attributes
-        let mut final_attrs = attrs_list
-            .unwrap_or_else(|| AttrsList::new(line.attrs_list().get_span(line.text().len())));
+        let mut final_attrs = attrs_list.unwrap_or_else(|| {
+            AttrsList::new(
+                line.attrs_list()
+                    .get_span(self.cursor.index.saturating_sub(1)),
+            )
+        });
 
         // Append the inserted text, line by line
         // we want to see a blank entry if the string ends with a newline

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -613,14 +613,14 @@ impl Edit for Editor {
             Action::NextWord => {
                 let line: &mut BufferLine = &mut self.buffer.lines[self.cursor.line];
                 if self.cursor.index < line.text().len() {
-                    for (i, word) in line.text().unicode_word_indices() {
-                        let i = i + word.len();
-                        if i > self.cursor.index {
-                            self.cursor.index = i;
-                            self.buffer.set_redraw(true);
-                            break;
-                        }
-                    }
+                    self.cursor.index = line
+                        .text()
+                        .unicode_word_indices()
+                        .map(|(i, word)| i + word.len())
+                        .find(|&i| i > self.cursor.index)
+                        .unwrap_or(line.text().len());
+
+                    self.buffer.set_redraw(true);
                 } else if self.cursor.line + 1 < self.buffer.lines.len() {
                     self.cursor.line += 1;
                     self.cursor.index = 0;

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -592,16 +592,14 @@ impl Edit for Editor {
             Action::PreviousWord => {
                 let line: &mut BufferLine = &mut self.buffer.lines[self.cursor.line];
                 if self.cursor.index > 0 {
-                    let mut prev_index = 0;
-                    for (i, _) in line.text().unicode_word_indices() {
-                        if i < self.cursor.index {
-                            prev_index = i;
-                        } else {
-                            break;
-                        }
-                    }
+                    self.cursor.index = line
+                        .text()
+                        .unicode_word_indices()
+                        .rev()
+                        .map(|(i, _)| i)
+                        .find(|&i| i < self.cursor.index)
+                        .unwrap_or(0);
 
-                    self.cursor.index = prev_index;
                     self.buffer.set_redraw(true);
                 } else if self.cursor.line > 0 {
                     self.cursor.line -= 1;

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -109,7 +109,7 @@ impl Edit for Editor {
         }
     }
 
-    fn copy_selection(&mut self) -> Option<String> {
+    fn copy_selection(&self) -> Option<String> {
         let select = self.select_opt?;
 
         let (start, end) = match select.line.cmp(&self.cursor.line) {

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -288,6 +288,7 @@ impl Edit for Editor {
 
         // Append the text after insertion
         self.cursor.index = self.buffer.lines[self.cursor.line].text().len() - after_len;
+        self.cursor_moved = true;
     }
 
     fn action(&mut self, font_system: &mut FontSystem, action: Action) {

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -115,7 +115,7 @@ pub trait Edit {
     fn shape_as_needed(&mut self, font_system: &mut FontSystem);
 
     /// Copy selection
-    fn copy_selection(&mut self) -> Option<String>;
+    fn copy_selection(&self) -> Option<String>;
 
     /// Delete selection, adjusting cursor and returning true if there was a selection
     // Also used by backspace, delete, insert, and enter when there is a selection

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -250,7 +250,7 @@ impl<'a> Edit for SyntaxEditor<'a> {
         self.editor.shape_as_needed(font_system);
     }
 
-    fn copy_selection(&mut self) -> Option<String> {
+    fn copy_selection(&self) -> Option<String> {
         self.editor.copy_selection()
     }
 

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -81,7 +81,7 @@ impl<'a> Edit for ViEditor<'a> {
         self.editor.shape_as_needed(font_system);
     }
 
-    fn copy_selection(&mut self) -> Option<String> {
+    fn copy_selection(&self) -> Option<String> {
         self.editor.copy_selection()
     }
 


### PR DESCRIPTION
This PR fixes some small issues I have found in the `Editor` logic while working on [the `text-editor` branch for `iced`](https://github.com/iced-rs/iced/compare/text-editor).

The commits should be self-descriptive.