### PR TITLE
Implement no_std compatible ab_glyph glyph rendering backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ rust-version = "1.65"
 fontdb = { version = "0.14.1", default-features = false }
 libm = "0.2.7"
 log = "0.4.20"
-rustybuzz = { version = "0.10.0", default-features = false, features = ["libm"] }
+rustybuzz = { version = "0.10.0", default-features = false, features = [
+    "libm",
+] }
 swash = { version = "0.1.8", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
@@ -24,6 +26,12 @@ rangemap = "1.3.0"
 hashbrown = { version = "0.14.0", optional = true, default-features = false }
 rustc-hash = { version = "1.1.0", default-features = false }
 self_cell = "1.0.1"
+ab_glyph = { version = "0.2.22", default-features = false, optional = true, features = [
+    "variable-fonts",
+] }
+rgb = { version = "0.8.36", default-features = false, optional = true }
+zune-png = { version = "0.2.1", default-features = false, optional = true }
+resize = { version = "0.8.1", default-features = false, optional = true }
 
 [dependencies.unicode-bidi]
 version = "0.3.13"
@@ -32,18 +40,23 @@ features = ["hardcoded-data"]
 
 [features]
 default = ["std", "swash", "fontconfig"]
-no_std = ["rustybuzz/libm", "hashbrown"]
+no_std = ["rustybuzz/libm", "hashbrown", "ab_glyph?/libm", "resize?/no_std"]
 std = [
     "fontdb/memmap",
     "fontdb/std",
     "rustybuzz/std",
     "sys-locale",
     "unicode-bidi/std",
+    "ab_glyph?/std",
+    "zune-png?/std",
+    "resize?/std",
 ]
 vi = ["syntect"]
 wasm-web = ["sys-locale?/js"]
 warn_on_missing_glyphs = []
 fontconfig = ["fontdb/fontconfig", "std"]
+# glyph image support for ab_glyph rendering backend, no_std
+ab_glyph_image = ["ab_glyph", "dep:zune-png", "dep:rgb", "dep:resize"]
 
 [[bench]]
 name = "layout"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following features must be supported before this is "ready":
     - [ ] no_std font loading
     - [x] no_std shaping
     - [x] no_std layout
-    - [ ] no_std rendering
+    - [x] no_std rendering (using ab_glyph, incomplete color emoji support)
 
 The UDHR (Universal Declaration of Human Rights) test involves taking the entire
 set of UDHR translations (almost 500 languages), concatenating them as one file

--- a/ci.sh
+++ b/ci.sh
@@ -16,11 +16,17 @@ build
 echo Build with only no_std feature
 build --no-default-features --features no_std
 
+echo Build with only no_std and ab_glyph feature
+build --no-default-features --features no_std,ab_glyph
+
 echo Build with only std feature
 build --no-default-features --features std
 
 echo Build with only std and swash features
 build --no-default-features --features std,swash
+
+echo Build with only std and ab_glyph features
+build --no-default-features --features std,ab_glyph
 
 echo Build with only std and syntect features
 build --no-default-features --features std,syntect

--- a/examples/editor-libcosmic/Cargo.toml
+++ b/examples/editor-libcosmic/Cargo.toml
@@ -27,3 +27,4 @@ version = "0.11"
 [features]
 default = []
 vi = ["cosmic-text/vi"]
+ab_glyph = ["cosmic-text/ab_glyph_image"]

--- a/examples/editor-libcosmic/src/text_box.rs
+++ b/examples/editor-libcosmic/src/text_box.rs
@@ -5,7 +5,11 @@ use cosmic::{
     iced_runtime::keyboard::KeyCode,
     theme::{Theme, ThemeType},
 };
-use cosmic_text::{Action, Edit, SwashCache};
+#[cfg(feature = "ab_glyph")]
+use cosmic_text::AbGlyphDraw;
+#[cfg(not(feature = "ab_glyph"))]
+use cosmic_text::SwashCache;
+use cosmic_text::{Action, Edit};
 use std::{cmp, sync::Mutex, time::Instant};
 
 use crate::FONT_SYSTEM;
@@ -232,8 +236,8 @@ where
 
         // Draw to pixel buffer
         let mut pixels = vec![0; image_w as usize * image_h as usize * 4];
-        editor.draw(
-            &mut state.cache.lock().unwrap(),
+        editor.draw_with(
+            &mut (*state.cache.lock().unwrap()),
             text_color,
             |x, y, w, h, color| {
                 //TODO: improve performance
@@ -387,6 +391,9 @@ where
 
 pub struct State {
     is_dragging: bool,
+    #[cfg(feature = "ab_glyph")]
+    cache: Mutex<AbGlyphDraw>,
+    #[cfg(not(feature = "ab_glyph"))]
     cache: Mutex<SwashCache>,
 }
 
@@ -395,6 +402,9 @@ impl State {
     pub fn new() -> State {
         State {
             is_dragging: false,
+            #[cfg(feature = "ab_glyph")]
+            cache: Mutex::new(AbGlyphDraw::new()),
+            #[cfg(not(feature = "ab_glyph"))]
             cache: Mutex::new(SwashCache::new()),
         }
     }

--- a/examples/editor-orbclient/Cargo.toml
+++ b/examples/editor-orbclient/Cargo.toml
@@ -17,3 +17,4 @@ unicode-segmentation = "1.7"
 [features]
 default = []
 vi = ["cosmic-text/vi"]
+ab_glyph = ["cosmic-text/ab_glyph_image"]

--- a/examples/editor-orbclient/src/main.rs
+++ b/examples/editor-orbclient/src/main.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, SwashCache, SyntaxEditor,
-    SyntaxSystem,
+    Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, SyntaxEditor, SyntaxSystem,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{
@@ -81,7 +80,10 @@ fn main() {
         }
     }
 
-    let mut swash_cache = SwashCache::new();
+    #[cfg(feature = "ab_glyph")]
+    let mut renderer = cosmic_text::AbGlyphDraw::new();
+    #[cfg(not(feature = "ab_glyph"))]
+    let mut renderer = cosmic_text::SwashCache::new();
 
     let mut ctrl_pressed = false;
     let mut mouse_x = -1;
@@ -96,7 +98,7 @@ fn main() {
             window.set(orbclient::Color::rgb(bg.r(), bg.g(), bg.b()));
 
             let fg = editor.foreground_color();
-            editor.draw(&mut swash_cache, fg, |x, y, w, h, color| {
+            editor.draw_with(&mut renderer, fg, |x, y, w, h, color| {
                 window.rect(
                     line_x as i32 + x,
                     y,

--- a/examples/editor-test/Cargo.toml
+++ b/examples/editor-test/Cargo.toml
@@ -13,3 +13,6 @@ fontdb = "0.13"
 log = "0.4"
 orbclient = "0.3.35"
 unicode-segmentation = "1.7"
+
+[features]
+ab_glyph = ["cosmic-text/ab_glyph_image"]

--- a/examples/rich-text/Cargo.toml
+++ b/examples/rich-text/Cargo.toml
@@ -12,3 +12,6 @@ env_logger = "0.10"
 fontdb = "0.13"
 log = "0.4"
 orbclient = "0.3.35"
+
+[features]
+ab_glyph = ["cosmic-text/ab_glyph_image"]

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, Buffer, Color, Edit, Editor, Family, FontSystem, Metrics, Shaping, Style,
-    SwashCache, Weight,
+    Action, Attrs, Buffer, Color, Edit, Editor, Family, FontSystem, Metrics, Shaping, Style, Weight,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{
@@ -121,7 +120,11 @@ fn main() {
         .buffer_mut()
         .set_rich_text(spans.iter().copied(), Shaping::Advanced);
 
-    let mut swash_cache = SwashCache::new();
+    #[cfg(feature = "ab_glyph")]
+    let mut renderer = cosmic_text::AbGlyphDraw::new();
+    #[cfg(not(feature = "ab_glyph"))]
+    // A SwashCache stores rasterized glyphs, create one per application
+    let mut renderer = cosmic_text::SwashCache::new();
 
     //TODO: make window not async?
     let mut mouse_x = -1;
@@ -137,7 +140,7 @@ fn main() {
 
             window.set(bg_color);
 
-            editor.draw(&mut swash_cache, font_color, |x, y, w, h, color| {
+            editor.draw_with(&mut renderer, font_color, |x, y, w, h, color| {
                 window.rect(x, y, w, h, orbclient::Color { data: color.0 });
             });
 

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -12,3 +12,6 @@ env_logger = "0.10"
 fontdb = "0.13"
 log = "0.4"
 termion = "2.0"
+
+[features]
+ab_glyph = ["cosmic-text/ab_glyph_image"]

--- a/examples/terminal/src/main.rs
+++ b/examples/terminal/src/main.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cosmic_text::{Attrs, Buffer, Color, FontSystem, Metrics, Shaping, SwashCache};
+use cosmic_text::{Attrs, Buffer, Color, FontSystem, Metrics, Shaping};
 use std::cmp::{self, Ordering};
 use termion::{color, cursor};
 
@@ -8,8 +8,11 @@ fn main() {
     // A FontSystem provides access to detected system fonts, create one per application
     let mut font_system = FontSystem::new();
 
+    #[cfg(feature = "ab_glyph")]
+    let mut renderer = cosmic_text::AbGlyphDraw::new();
+    #[cfg(not(feature = "ab_glyph"))]
     // A SwashCache stores rasterized glyphs, create one per application
-    let mut swash_cache = SwashCache::new();
+    let mut renderer = cosmic_text::SwashCache::new();
 
     // Text metrics indicate the font size and line height of a buffer
     let metrics = Metrics::new(14.0, 20.0);
@@ -57,7 +60,7 @@ fn main() {
     // Print the buffer
     let mut last_x = 0;
     let mut last_y = 0;
-    buffer.draw(&mut swash_cache, text_color, |x, y, w, h, color| {
+    buffer.draw_with(&mut renderer, text_color, |x, y, w, h, color| {
         let a = color.a();
         if a == 0 || x < 0 || y < 0 || w != 1 || h != 1 {
             // Ignore alphas of 0, or invalid x, y coordinates, or unimplemented sizes

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -266,21 +266,29 @@ impl<'a> Edit for SyntaxEditor<'a> {
         self.editor.action(font_system, action);
     }
 
+    fn draw_with<D, F>(&self, font_system: &mut FontSystem, render: &mut D, _color: Color, mut f: F)
+    where
+        D: crate::Draw,
+        F: FnMut(i32, i32, u32, u32, Color),
+    {
+        let size = self.buffer().size();
+        f(0, 0, size.0 as u32, size.1 as u32, self.background_color());
+        self.editor
+            .draw_with(font_system, render, self.foreground_color(), f);
+    }
+
     /// Draw the editor
     #[cfg(feature = "swash")]
     fn draw<F>(
         &self,
         font_system: &mut FontSystem,
         cache: &mut crate::SwashCache,
-        _color: Color,
-        mut f: F,
+        color: Color,
+        f: F,
     ) where
         F: FnMut(i32, i32, u32, u32, Color),
     {
-        let size = self.buffer().size();
-        f(0, 0, size.0 as u32, size.1 as u32, self.background_color());
-        self.editor
-            .draw(font_system, cache, self.foreground_color(), f);
+        self.draw_with(font_system, cache, color, f);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,9 @@ mod font;
 pub use self::layout::*;
 mod layout;
 
+pub use self::render::*;
+mod render;
+
 pub use self::shape::*;
 mod shape;
 

--- a/src/render/ab_glyph.rs
+++ b/src/render/ab_glyph.rs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cfg(feature = "ab_glyph_image")]
+use alloc::borrow::Cow;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use ab_glyph::Font as AbGlyphFont;
+use ab_glyph::FontRef;
+use self_cell::self_cell;
+#[cfg(feature = "ab_glyph_image")]
+use zune_png::zune_core::colorspace::ColorSpace;
+
+use crate::{CacheKey, Color, Draw, Font, FontSystem, LayoutRun};
+
+type BuildHasher = core::hash::BuildHasherDefault<rustc_hash::FxHasher>;
+
+#[cfg(feature = "std")]
+type HashMap<K, V> = std::collections::HashMap<K, V, BuildHasher>;
+#[cfg(not(feature = "std"))]
+type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasher>;
+
+self_cell!(
+    struct OwnedFont {
+        owner: Arc<Font>,
+
+        #[covariant]
+        dependent: FontRef,
+    }
+
+    impl {Debug}
+);
+
+#[derive(Debug)]
+enum RenderGlyph {
+    Outline {
+        bounds: ab_glyph::Rect,
+        coverage: Vec<u8>,
+    },
+
+    #[cfg(feature = "ab_glyph_image")]
+    Image {
+        width: usize,
+        height: usize,
+        offset_x: i32,
+        offset_y: i32,
+        bitmap: Vec<Color>,
+    },
+}
+
+#[derive(Debug, Default)]
+pub struct AbGlyphDraw {
+    font_cache: HashMap<fontdb::ID, Option<OwnedFont>>,
+    glyph_cache: HashMap<CacheKey, Option<RenderGlyph>>,
+}
+
+impl AbGlyphDraw {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn render_glyph(
+        &mut self,
+        font_system: &mut FontSystem,
+        cache_key: &CacheKey,
+    ) -> Option<RenderGlyph> {
+        let font_size = f32::from_bits(cache_key.font_size_bits);
+
+        let font = self
+            .font_cache
+            .entry(cache_key.font_id)
+            .or_insert_with(|| {
+                let font = font_system.get_font(cache_key.font_id)?;
+                OwnedFont::try_new(font, |font| ab_glyph::FontRef::try_from_slice(font.data()))
+                    .ok()
+                    .or_else(|| {
+                        let face = font_system.db().face(cache_key.font_id)?;
+                        log::warn!(
+                            "failed to load font '{}' for ab_glyph",
+                            face.post_script_name
+                        );
+                        None
+                    })
+            })
+            .as_ref()?
+            .borrow_dependent();
+
+        let glyph_id = ab_glyph::GlyphId(cache_key.glyph_id);
+
+        // ab_glyph treat units of font height as 1 em instead of conventional units_per_em,
+        // and causing glyphs being rendered smaller. We re-scale it back to align with
+        // layouting result, see <https://github.com/alexheretic/ab-glyph/issues/15>
+        let rescale_factor = font
+            .units_per_em()
+            .map(|units_per_em| font.height_unscaled() / units_per_em)
+            .unwrap_or(1.0);
+        let glyph = glyph_id.with_scale_and_position(
+            font_size * rescale_factor,
+            ab_glyph::point(cache_key.x_bin.as_float(), cache_key.y_bin.as_float()),
+        );
+
+        if let Some(outlined_glyph) = font.outline_glyph(glyph) {
+            let bounds = outlined_glyph.px_bounds();
+            let width = bounds.width() as usize;
+            let height = bounds.height() as usize;
+            let mut coverage = vec![0u8; width * height];
+            outlined_glyph.draw(|x, y, c| {
+                let id = x as usize + y as usize * width;
+                coverage[id] = (c * 255.0) as _;
+            });
+            return Some(RenderGlyph::Outline { bounds, coverage });
+        }
+
+        #[cfg(feature = "ab_glyph_image")]
+        if let Some(image) = font.glyph_raster_image2(glyph_id, font_size as _) {
+            return convert_glyph_image(image, font_size);
+        };
+
+        None
+    }
+}
+
+#[cfg(feature = "ab_glyph_image")]
+fn convert_glyph_image(image: ab_glyph::v2::GlyphImage, font_size: f32) -> Option<RenderGlyph> {
+    match image.format {
+        ab_glyph::GlyphImageFormat::Png => {
+            use zune_png::zune_core::bit_depth::BitDepth;
+            let mut decoder = zune_png::PngDecoder::new(image.data);
+            let res = match decoder.decode() {
+                Ok(res) => res,
+                Err(e) => {
+                    log::error!("failed to decode PNG image: {:?}", e);
+                    return None;
+                }
+            };
+
+            let info = decoder.get_info()?;
+            let color_space = decoder.get_colorspace()?;
+
+            let mut data_u8;
+            let data_u16;
+            let data = match decoder.get_depth()? {
+                BitDepth::Eight => {
+                    data_u8 = res.u8()?;
+                    convert_u8_to_rgba8(&mut data_u8, color_space)?
+                }
+                BitDepth::Sixteen => {
+                    data_u16 = res.u16()?;
+                    Cow::Owned(convert_u16_to_rgba8(&data_u16, color_space)?)
+                }
+                _ => {
+                    return None;
+                }
+            };
+
+            let scale = font_size / image.pixels_per_em as f32;
+            let offset_x = (-image.origin.x * scale) as i32;
+            let offset_y = (-(image.origin.y + info.height as f32) * scale) as i32;
+
+            let (data, width, height) = resize_rgba8(&data, info.width, info.height, scale)?;
+
+            Some(RenderGlyph::Image {
+                width,
+                height,
+                offset_x,
+                offset_y,
+                bitmap: rgba8_to_color_bitmap(&data),
+            })
+        }
+        _ => {
+            // XXX: current ab_glyph api does not provides width and height info for glyph
+            // image so there is no way to indexing the bitmap data, though we can decode
+            // those info from PNG data header
+            log::warn!("glyph image format {:?} not supported yet", image.format);
+            None
+        }
+    }
+}
+
+impl Draw for AbGlyphDraw {
+    fn draw_line<F>(
+        &mut self,
+        font_system: &mut FontSystem,
+        run: &LayoutRun,
+        color: Color,
+        f: &mut F,
+    ) where
+        F: FnMut(i32, i32, u32, u32, Color),
+    {
+        for glyph in run.glyphs.iter() {
+            let physical_glyph = glyph.physical((0., 0.), 1.0);
+
+            let glyph_color = glyph.color_opt.unwrap_or(color);
+
+            // move out glyph_cache to allow mutable reference to self in closure
+            let mut glyph_cache = core::mem::take(&mut self.glyph_cache);
+            let render_glyph = glyph_cache
+                .entry(physical_glyph.cache_key)
+                .or_insert_with(|| self.render_glyph(font_system, &physical_glyph.cache_key))
+                .as_ref();
+
+            if let Some(render_glyph) = render_glyph {
+                match render_glyph {
+                    RenderGlyph::Outline { bounds, coverage } => {
+                        let width = bounds.width() as usize;
+                        let height = bounds.height() as usize;
+
+                        for y in 0..height {
+                            for x in 0..width {
+                                let color = color_blend_alpha(glyph_color, coverage[x + y * width]);
+                                let x = x as i32 + physical_glyph.x + (bounds.min.x) as i32;
+                                let y = y as i32
+                                    + physical_glyph.y
+                                    + (run.line_y + bounds.min.y) as i32;
+
+                                f(x, y, 1, 1, color);
+                            }
+                        }
+                    }
+
+                    #[cfg(feature = "ab_glyph_image")]
+                    RenderGlyph::Image {
+                        width,
+                        height,
+                        offset_x,
+                        offset_y,
+                        bitmap,
+                    } => {
+                        for y in 0..*height {
+                            for x in 0..*width {
+                                let color = bitmap[x + y * width];
+                                let x = x as i32 + physical_glyph.x + offset_x;
+                                let y = y as i32 + physical_glyph.y + run.line_y as i32 + offset_y;
+
+                                f(x, y, 1, 1, color);
+                            }
+                        }
+                    }
+                }
+            };
+            // move back glyph_cache
+            self.glyph_cache = glyph_cache;
+        }
+    }
+}
+
+// Copied from tiny-skia
+#[inline]
+fn premultiply_u8(c: u8, a: u8) -> u8 {
+    let prod = u32::from(c) * u32::from(a) + 128;
+    ((prod + (prod >> 8)) >> 8) as u8
+}
+
+#[inline]
+fn color_blend_alpha(c: Color, a: u8) -> Color {
+    let a = premultiply_u8(c.a(), a);
+    Color(((a as u32) << 24) | c.0 & 0xFF_FF_FF)
+}
+
+#[cfg(feature = "ab_glyph_image")]
+fn convert_u8_to_rgba8(data: &mut [u8], color_space: ColorSpace) -> Option<Cow<[rgb::RGBA8]>> {
+    use rgb::FromSlice;
+    let data = match color_space {
+        ColorSpace::RGBA => Cow::Borrowed(data.as_rgba()),
+        ColorSpace::BGRA => {
+            data.as_bgra_mut()
+                .iter_mut()
+                .for_each(|c| core::mem::swap(&mut c.b, &mut c.r));
+            Cow::Borrowed(data.as_rgba())
+        }
+        ColorSpace::RGB => {
+            let data = data
+                .as_rgb()
+                .iter()
+                .map(|c| rgb::RGBA8::new(c.r, c.g, c.b, 255))
+                .collect();
+            Cow::Owned(data)
+        }
+        ColorSpace::BGR => {
+            let data = data
+                .as_bgr()
+                .iter()
+                .map(|c| rgb::RGBA8::new(c.r, c.g, c.b, 255))
+                .collect();
+            Cow::Owned(data)
+        }
+        ColorSpace::Luma => {
+            let data = data
+                .as_gray()
+                .iter()
+                .map(|c| rgb::RGBA8::new(c.0, c.0, c.0, 255))
+                .collect();
+            Cow::Owned(data)
+        }
+        ColorSpace::LumaA => {
+            let data = data
+                .as_gray_alpha()
+                .iter()
+                .map(|c| rgb::RGBA8::new(c.0, c.0, c.0, c.1))
+                .collect();
+            Cow::Owned(data)
+        }
+        _ => {
+            // PNG does not support these color spaces, it's fine to not implement support for them
+            log::warn!(
+                "glyph image color space {:?} not supported yet",
+                color_space
+            );
+            return None;
+        }
+    };
+    Some(data)
+}
+
+#[cfg(feature = "ab_glyph_image")]
+fn convert_u16_to_rgba8(data: &[u16], color_space: ColorSpace) -> Option<Vec<rgb::RGBA8>> {
+    use rgb::FromSlice;
+
+    #[inline(always)]
+    fn cvt(color: u16) -> u8 {
+        ((color + 0b0_1000_0000) >> 8) as u8
+    }
+
+    let data: Vec<rgb::RGBA8> = match color_space {
+        ColorSpace::RGBA => data
+            .as_rgba()
+            .iter()
+            .map(|c| rgb::RGBA8::new(cvt(c.r), cvt(c.g), cvt(c.b), cvt(c.a)))
+            .collect(),
+        ColorSpace::BGRA => data
+            .as_bgra()
+            .iter()
+            .map(|c| rgb::RGBA8::new(cvt(c.r), cvt(c.g), cvt(c.b), cvt(c.a)))
+            .collect(),
+        ColorSpace::RGB => data
+            .as_rgb()
+            .iter()
+            .map(|c| rgb::RGBA8::new(cvt(c.r), cvt(c.g), cvt(c.b), 0xff))
+            .collect(),
+        ColorSpace::BGR => data
+            .as_bgr()
+            .iter()
+            .map(|c| rgb::RGBA8::new(cvt(c.r), cvt(c.g), cvt(c.b), 0xff))
+            .collect(),
+        ColorSpace::Luma => data
+            .as_gray()
+            .iter()
+            .map(|c| {
+                let l = cvt(c.0);
+                rgb::RGBA8::new(l, l, l, 0xff)
+            })
+            .collect(),
+        ColorSpace::LumaA => data
+            .as_gray_alpha()
+            .iter()
+            .map(|c| {
+                let l = cvt(c.0);
+                rgb::RGBA8::new(l, l, l, cvt(c.1))
+            })
+            .collect(),
+        _ => {
+            // PNG does not support these color spaces, it's fine to not implement support for them
+            log::warn!(
+                "glyph image color space {:?} not supported yet",
+                color_space
+            );
+            return None;
+        }
+    };
+    Some(data)
+}
+
+#[cfg(feature = "ab_glyph_image")]
+fn rgba8_to_color_bitmap(data: &[rgb::RGBA8]) -> Vec<Color> {
+    data.iter()
+        .map(|c| Color::rgba(c.r, c.g, c.b, c.a))
+        .collect()
+}
+
+#[cfg(feature = "ab_glyph_image")]
+fn resize_rgba8(
+    data: &[rgb::RGBA8],
+    width: usize,
+    height: usize,
+    scale: f32,
+) -> Option<(Cow<[rgb::RGBA8]>, usize, usize)> {
+    if scale == 1.0 {
+        return Some((Cow::Borrowed(data), width, height));
+    }
+
+    let dst_width = (width as f32 * scale) as usize;
+    let dst_height = (height as f32 * scale) as usize;
+
+    let mut resizer = resize::new(
+        width,
+        height,
+        dst_width,
+        dst_height,
+        resize::Pixel::RGBA8P,
+        resize::Type::Mitchell,
+    )
+    .map_err(|e| {
+        log::error!("failed to create resizer: {}", e);
+        e
+    })
+    .ok()?;
+
+    let mut dst = vec![rgb::RGBA8::default(); dst_width * dst_height];
+    resizer
+        .resize(data, &mut dst)
+        .map_err(|e| {
+            log::error!("failed to resize: {}", e);
+            e
+        })
+        .ok()?;
+    Some((Cow::Owned(dst), dst_width, dst_height))
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{Color, FontSystem, LayoutRun};
+
+/// A trait to represent glyph renderer
+pub trait Draw {
+    /// Draw a line of laid out glyphs
+    fn draw_line<F>(
+        &mut self,
+        font_system: &mut FontSystem,
+        run: &LayoutRun<'_>,
+        color: Color,
+        f: &mut F,
+    ) where
+        F: FnMut(i32, i32, u32, u32, Color);
+}
+
+#[cfg(feature = "swash")]
+mod swash;
+#[cfg(feature = "swash")]
+pub use self::swash::*;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,6 +15,11 @@ pub trait Draw {
         F: FnMut(i32, i32, u32, u32, Color);
 }
 
+#[cfg(feature = "ab_glyph")]
+mod ab_glyph;
+#[cfg(feature = "ab_glyph")]
+pub use self::ab_glyph::*;
+
 #[cfg(feature = "swash")]
 mod swash;
 #[cfg(feature = "swash")]

--- a/src/render/swash.rs
+++ b/src/render/swash.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{Color, Draw, FontSystem, LayoutRun, SwashCache};
+
+impl Draw for SwashCache {
+    fn draw_line<F>(
+        &mut self,
+        font_system: &mut FontSystem,
+        run: &LayoutRun,
+        color: Color,
+        f: &mut F,
+    ) where
+        F: FnMut(i32, i32, u32, u32, Color),
+    {
+        for glyph in run.glyphs.iter() {
+            let physical_glyph = glyph.physical((0., 0.), 1.0);
+
+            let glyph_color = match glyph.color_opt {
+                Some(some) => some,
+                None => color,
+            };
+
+            self.with_pixels(
+                font_system,
+                physical_glyph.cache_key,
+                glyph_color,
+                |x, y, color| {
+                    f(
+                        physical_glyph.x + x,
+                        run.line_y as i32 + physical_glyph.y + y,
+                        1,
+                        1,
+                        color,
+                    );
+                },
+            );
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE] 
> ~~This PR depends on #183 and #184 . Please review & merge those first.~~ Merged or have alternative #188 .

### Implement no_std compatible ab_glyph glyph rendering backend

This uses ab_glyph to scale & rasterize glyph outline and load glyph image, it
can be served as an alternative to swash.

For glyph image(e.g. color emoji) rendering, only support for images in PNG
format are currently implemented due to upstream limitation.

<details>
<summary>Screenshot of demo targeting no_std x86_64-unknown-uefi</summary>

![Qemu UEFI](https://github.com/pop-os/cosmic-text/assets/24871166/d8b29f9a-d58e-4aae-9e39-5d89936e0972)

</details>

---

### Add ab_glyph feature to examples and use the new draw_with method

Run examples with `cargo run --features ab_glyph` to test ab_glyph rendering.

