### PR TITLE
Fix building editor-libcosmic with vi feature

### DIFF
--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -269,6 +269,7 @@ impl Application for Window {
 
                 let mut editor = self.editor.lock().unwrap();
 
+                #[cfg(not(feature = "vi"))]
                 // Update the syntax color theme
                 match theme {
                     "Light" => editor.update_theme("base16-ocean.light"),


### PR DESCRIPTION
The vi editor has no update_theme method, fix it with feature gate.