### PR TITLE
Respect `fontconfig` font aliases when enabled

### DIFF
--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -58,12 +58,13 @@ impl FontSystem {
         log::debug!("Locale: {}", locale);
 
         let mut db = fontdb::Database::new();
-        Self::load_fonts(&mut db, fonts.into_iter());
 
         //TODO: configurable default fonts
         db.set_monospace_family("Fira Mono");
         db.set_sans_serif_family("Fira Sans");
         db.set_serif_family("DejaVu Serif");
+
+        Self::load_fonts(&mut db, fonts.into_iter());
 
         Self::new_with_locale_and_db(locale, db)
     }


### PR DESCRIPTION
I noticed my `fontconfig` aliases were not having any effect.

`fontdb` [tries to respect these by setting the default families during `load_system_fonts`](https://docs.rs/fontdb/latest/src/fontdb/lib.rs.html#455).

By setting the default values first, then loading the fonts after we let the values be overriden.