### PR TITLE
Abstract glyph drawing logic as Draw trait

### DIFF
--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -266,21 +266,29 @@ impl<'a> Edit for SyntaxEditor<'a> {
         self.editor.action(font_system, action);
     }
 
+    fn draw_with<D, F>(&self, font_system: &mut FontSystem, render: &mut D, _color: Color, mut f: F)
+    where
+        D: crate::Draw,
+        F: FnMut(i32, i32, u32, u32, Color),
+    {
+        let size = self.buffer().size();
+        f(0, 0, size.0 as u32, size.1 as u32, self.background_color());
+        self.editor
+            .draw_with(font_system, render, self.foreground_color(), f);
+    }
+
     /// Draw the editor
     #[cfg(feature = "swash")]
     fn draw<F>(
         &self,
         font_system: &mut FontSystem,
         cache: &mut crate::SwashCache,
-        _color: Color,
-        mut f: F,
+        color: Color,
+        f: F,
     ) where
         F: FnMut(i32, i32, u32, u32, Color),
     {
-        let size = self.buffer().size();
-        f(0, 0, size.0 as u32, size.1 as u32, self.background_color());
-        self.editor
-            .draw(font_system, cache, self.foreground_color(), f);
+        self.draw_with(font_system, cache, color, f);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,9 @@ mod font;
 pub use self::layout::*;
 mod layout;
 
+pub use self::render::*;
+mod render;
+
 pub use self::shape::*;
 mod shape;
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{Color, FontSystem, LayoutRun};
+
+/// A trait to represent glyph renderer
+pub trait Draw {
+    /// Draw a line of laid out glyphs
+    fn draw_line<F>(
+        &mut self,
+        font_system: &mut FontSystem,
+        run: &LayoutRun<'_>,
+        color: Color,
+        f: &mut F,
+    ) where
+        F: FnMut(i32, i32, u32, u32, Color);
+}
+
+#[cfg(feature = "swash")]
+mod swash;
+#[cfg(feature = "swash")]
+pub use self::swash::*;

--- a/src/render/swash.rs
+++ b/src/render/swash.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{Color, Draw, FontSystem, LayoutRun, SwashCache};
+
+impl Draw for SwashCache {
+    fn draw_line<F>(
+        &mut self,
+        font_system: &mut FontSystem,
+        run: &LayoutRun,
+        color: Color,
+        f: &mut F,
+    ) where
+        F: FnMut(i32, i32, u32, u32, Color),
+    {
+        for glyph in run.glyphs.iter() {
+            let physical_glyph = glyph.physical((0., 0.), 1.0);
+
+            let glyph_color = match glyph.color_opt {
+                Some(some) => some,
+                None => color,
+            };
+
+            self.with_pixels(
+                font_system,
+                physical_glyph.cache_key,
+                glyph_color,
+                |x, y, color| {
+                    f(
+                        physical_glyph.x + x,
+                        run.line_y as i32 + physical_glyph.y + y,
+                        1,
+                        1,
+                        color,
+                    );
+                },
+            );
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE] 
> This is separated from #185 for easier review.

The trait contains only one method, draw_line, which is going to be implemented by glyph rendering backend like swash to scale & rasterize inputed glyphs and draw pixels of them.

This make it easier to implement other rendering backend, and allows switching rendering backend at runtime.

The original code of glyph rendering for swash is moved into Draw.

And add draw_with method to Buffer and Edit interfaces to draw with glyph rendering backend that implemented Draw trait. The original glyph drawing part using swash in buffer and editor is also migrated to using Draw.

---

I am thinking we could also deprecate swash specific `draw` methods in Buffer and Edit to use `draw_with` instead. Or just modify the interface of `draw`.


