### PR TITLE
Fix rendering of RTL words

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1221,11 +1221,12 @@ impl ShapeLine {
                                 } else {
                                     0.0
                                 };
-                            let y_advance = font_size * glyph.y_advance;
-                            glyphs.push(glyph.layout(font_size, x, y, x_advance, span.level));
                             if self.rtl {
                                 x -= x_advance;
-                            } else {
+                            }
+                            let y_advance = font_size * glyph.y_advance;
+                            glyphs.push(glyph.layout(font_size, x, y, x_advance, span.level));
+                            if !self.rtl {
                                 x += x_advance;
                             }
                             y += y_advance;


### PR DESCRIPTION
Fixes (I think, my understanding of the code is very limited) issue #190.

A related question:

I see that there are no tests for these type of issues. 

I can add a few tests for Hebrew, and English. My thinking is to use an open source font to render an image of a word or a paragraph to an image, and compare it against a master image saved in the repository. That should catch these kinds of issues at least..

Would that be desired/helpful?

