### PR TITLE
Bump `fontdb` to `0.16`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/pop-os/cosmic-text"
 rust-version = "1.65"
 
 [dependencies]
-fontdb = { version = "0.15.0", default-features = false }
+fontdb = { version = "0.16.0", default-features = false }
 libm = "0.2.8"
 log = "0.4.20"
 rustybuzz = { version = "0.11.0", default-features = false, features = ["libm"] }

--- a/deny.toml
+++ b/deny.toml
@@ -179,7 +179,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
+multiple-versions = "deny"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates


### PR DESCRIPTION
We were getting duplicate `ttf-parser` dependencies because of `rustybuzz` releasing its `ttf-parser 0.20` upgrade out of sync with `fontdb 0.16`, whose update just got published.
