### PR TITLE
Don't use Emoji fonts as monospace fallback

### DIFF
--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -130,10 +130,14 @@ impl<'a> Iterator for FontFallbackIter<'a> {
                 }
                 // Set a monospace fallback if Monospace family is not found
                 if self.default_families[self.default_i - 1] == &Family::Monospace
-                    && self.font_system.db().face(*id).map(|f| f.monospaced) == Some(true)
                     && monospace_fallback.is_none()
                 {
-                    monospace_fallback = Some(id);
+                    if let Some(face_info) = self.font_system.db().face(*id) {
+                        // Don't use emoji fonts as Monospace
+                        if face_info.monospaced && !face_info.post_script_name.contains("Emoji") {
+                            monospace_fallback = Some(id);
+                        }
+                    }
                 }
             }
             // If default family is Monospace fallback to first monospaced font


### PR DESCRIPTION
For some reason, on my system Noto Color Emoji is the first "monospace" font in the `FontSystem`, so it gets used as the fallback. This is of course not optimal because it does not contain any Latin characters. It seems like there are more problems with how system fonts are matched, because `fc-match` shows different fonts from the ones used by this library. But I haven't figured out how that works yet.