### PR TITLE
refresh the attrs more often in basic shaping

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -345,6 +345,7 @@ fn shape_skip(
             .map(|(i, codepoint)| {
                 let glyph_id = charmap.map(codepoint);
                 let x_advance = glyph_metrics.advance_width(glyph_id);
+                let attrs = attrs_list.get_span(i);
 
                 ShapeGlyph {
                     start: i,


### PR DESCRIPTION
Noticed when trying to migrate to cosmic-text in [bevy](https://github.com/bevyengine/bevy/pull/10193), the colors was not updated correctly when using Shaping::Basic