### PR TITLE
Refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ self_cell = "1.0.1"
 swash = { version = "0.1.8", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
+ttf-parser = "0.20.0"
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/pop-os/cosmic-text"
 rust-version = "1.65"
 
 [dependencies]
+bitflags = "2.4.1"
 cosmic_undo_2 = { version = "0.2.0", optional = true }
 fontdb = { version = "0.16.0", default-features = false }
 hashbrown = { version = "0.14.1", optional = true, default-features = false }

--- a/examples/editor-libcosmic/Cargo.toml
+++ b/examples/editor-libcosmic/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-cosmic-text = { path = "../../", features = ["syntect"] }
+cosmic-text = { path = "../../", features = ["syntect", "vi"] }
 env_logger = "0.10"
 fontdb = "0.13"
 lazy_static = "1.4"
@@ -26,4 +26,4 @@ version = "0.11"
 
 [features]
 default = []
-vi = ["cosmic-text/vi"]
+vi = []

--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -372,7 +372,7 @@ impl Application for Window {
     }
 }
 
-fn update_attrs<T: Edit>(editor: &mut T, attrs: Attrs) {
+fn update_attrs<'buffer, E: Edit<'buffer>>(editor: &mut E, attrs: Attrs) {
     editor.with_buffer_mut(|buffer| {
         buffer.lines.iter_mut().for_each(|line| {
             line.set_attrs_list(AttrsList::new(attrs));
@@ -380,7 +380,7 @@ fn update_attrs<T: Edit>(editor: &mut T, attrs: Attrs) {
     });
 }
 
-fn update_alignment<T: Edit>(editor: &mut T, align: Align) {
+fn update_alignment<'buffer, E: Edit<'buffer>>(editor: &mut E, align: Align) {
     let current_line = editor.cursor().line;
     let selection_bounds_opt = editor.selection_bounds();
     editor.with_buffer_mut(|buffer| {

--- a/examples/editor-libcosmic/src/main.rs
+++ b/examples/editor-libcosmic/src/main.rs
@@ -86,9 +86,6 @@ pub struct Window {
     path_opt: Option<PathBuf>,
     attrs: Attrs<'static>,
     font_size: FontSize,
-    #[cfg(not(feature = "vi"))]
-    editor: Mutex<SyntaxEditor<'static>>,
-    #[cfg(feature = "vi")]
     editor: Mutex<cosmic_text::ViEditor<'static>>,
 }
 
@@ -133,7 +130,7 @@ impl Application for Window {
     fn new(_flags: ()) -> (Self, Command<Self::Message>) {
         let attrs = cosmic_text::Attrs::new().family(cosmic_text::Family::Monospace);
 
-        let mut editor = SyntaxEditor::new(
+        let editor = SyntaxEditor::new(
             Buffer::new(
                 &mut FONT_SYSTEM.lock().unwrap(),
                 FontSize::Body.to_metrics(),
@@ -143,8 +140,8 @@ impl Application for Window {
         )
         .unwrap();
 
-        #[cfg(feature = "vi")]
         let mut editor = cosmic_text::ViEditor::new(editor);
+        editor.set_passthrough(cfg!(feature = "vi"));
 
         update_attrs(&mut editor, attrs);
 

--- a/examples/editor-libcosmic/src/text_box.rs
+++ b/examples/editor-libcosmic/src/text_box.rs
@@ -131,12 +131,10 @@ where
     fn layout(&self, _renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
         let limits = limits.width(Length::Fill).height(Length::Fill);
 
-        //TODO: allow lazy shape
         let mut editor = self.editor.lock().unwrap();
         editor
             .borrow_with(&mut FONT_SYSTEM.lock().unwrap())
-            .buffer_mut()
-            .shape_until(i32::max_value());
+            .shape_as_needed(true);
 
         let mut layout_lines = 0;
         for line in editor.buffer().lines.iter() {
@@ -148,7 +146,6 @@ where
 
         let height = layout_lines as f32 * editor.buffer().metrics().line_height;
         let size = Size::new(limits.max().width, height);
-        log::info!("size {:?}", size);
 
         layout::Node::new(limits.resolve(size))
     }
@@ -228,7 +225,7 @@ where
         editor.buffer_mut().set_size(image_w as f32, image_h as f32);
 
         // Shape and layout
-        editor.shape_as_needed();
+        editor.shape_as_needed(true);
 
         // Draw to pixel buffer
         let mut pixels = vec![0; image_w as usize * image_h as usize * 4];

--- a/examples/editor-libcosmic/src/text_box.rs
+++ b/examples/editor-libcosmic/src/text_box.rs
@@ -5,7 +5,7 @@ use cosmic::{
     iced_runtime::keyboard::KeyCode,
     theme::{Theme, ThemeType},
 };
-use cosmic_text::{Action, Edit, SwashCache};
+use cosmic_text::{Action, Edit, Motion, SwashCache};
 use std::{cmp, sync::Mutex, time::Instant};
 
 use crate::FONT_SYSTEM;
@@ -281,35 +281,35 @@ where
         match event {
             Event::Keyboard(keyboard::Event::KeyPressed { key_code, .. }) => match key_code {
                 KeyCode::Left => {
-                    editor.action(Action::Left);
+                    editor.action(Action::Motion(Motion::Left));
                     status = Status::Captured;
                 }
                 KeyCode::Right => {
-                    editor.action(Action::Right);
+                    editor.action(Action::Motion(Motion::Right));
                     status = Status::Captured;
                 }
                 KeyCode::Up => {
-                    editor.action(Action::Up);
+                    editor.action(Action::Motion(Motion::Up));
                     status = Status::Captured;
                 }
                 KeyCode::Down => {
-                    editor.action(Action::Down);
+                    editor.action(Action::Motion(Motion::Down));
                     status = Status::Captured;
                 }
                 KeyCode::Home => {
-                    editor.action(Action::Home);
+                    editor.action(Action::Motion(Motion::Home));
                     status = Status::Captured;
                 }
                 KeyCode::End => {
-                    editor.action(Action::End);
+                    editor.action(Action::Motion(Motion::End));
                     status = Status::Captured;
                 }
                 KeyCode::PageUp => {
-                    editor.action(Action::PageUp);
+                    editor.action(Action::Motion(Motion::PageUp));
                     status = Status::Captured;
                 }
                 KeyCode::PageDown => {
-                    editor.action(Action::PageDown);
+                    editor.action(Action::Motion(Motion::PageDown));
                     status = Status::Captured;
                 }
                 KeyCode::Escape => {

--- a/examples/editor-orbclient/src/main.rs
+++ b/examples/editor-orbclient/src/main.rs
@@ -95,8 +95,7 @@ fn main() {
             let bg = editor.background_color();
             window.set(orbclient::Color::rgb(bg.r(), bg.g(), bg.b()));
 
-            let fg = editor.foreground_color();
-            editor.draw(&mut swash_cache, fg, |x, y, w, h, color| {
+            editor.draw(&mut swash_cache, |x, y, w, h, color| {
                 window.rect(
                     line_x as i32 + x,
                     y,

--- a/examples/editor-orbclient/src/main.rs
+++ b/examples/editor-orbclient/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, SwashCache, SyntaxEditor,
+    Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, Motion, SwashCache, SyntaxEditor,
     SyntaxSystem,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
@@ -147,14 +147,26 @@ fn main() {
             match event.to_option() {
                 EventOption::Key(event) => match event.scancode {
                     orbclient::K_CTRL => ctrl_pressed = event.pressed,
-                    orbclient::K_LEFT if event.pressed => editor.action(Action::Left),
-                    orbclient::K_RIGHT if event.pressed => editor.action(Action::Right),
-                    orbclient::K_UP if event.pressed => editor.action(Action::Up),
-                    orbclient::K_DOWN if event.pressed => editor.action(Action::Down),
-                    orbclient::K_HOME if event.pressed => editor.action(Action::Home),
-                    orbclient::K_END if event.pressed => editor.action(Action::End),
-                    orbclient::K_PGUP if event.pressed => editor.action(Action::PageUp),
-                    orbclient::K_PGDN if event.pressed => editor.action(Action::PageDown),
+                    orbclient::K_LEFT if event.pressed => {
+                        editor.action(Action::Motion(Motion::Left))
+                    }
+                    orbclient::K_RIGHT if event.pressed => {
+                        editor.action(Action::Motion(Motion::Right))
+                    }
+                    orbclient::K_UP if event.pressed => editor.action(Action::Motion(Motion::Up)),
+                    orbclient::K_DOWN if event.pressed => {
+                        editor.action(Action::Motion(Motion::Down))
+                    }
+                    orbclient::K_HOME if event.pressed => {
+                        editor.action(Action::Motion(Motion::Home))
+                    }
+                    orbclient::K_END if event.pressed => editor.action(Action::Motion(Motion::End)),
+                    orbclient::K_PGUP if event.pressed => {
+                        editor.action(Action::Motion(Motion::PageUp))
+                    }
+                    orbclient::K_PGDN if event.pressed => {
+                        editor.action(Action::Motion(Motion::PageDown))
+                    }
                     orbclient::K_ESC if event.pressed => editor.action(Action::Escape),
                     orbclient::K_ENTER if event.pressed => editor.action(Action::Enter),
                     orbclient::K_BKSP if event.pressed => editor.action(Action::Backspace),

--- a/examples/editor-orbclient/src/main.rs
+++ b/examples/editor-orbclient/src/main.rs
@@ -88,7 +88,7 @@ fn main() {
     let mut mouse_y = -1;
     let mut mouse_left = false;
     loop {
-        editor.shape_as_needed();
+        editor.shape_as_needed(true);
         if editor.buffer().redraw() {
             let instant = Instant::now();
 

--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -15,6 +15,8 @@ fn redraw(
 ) {
     let bg_color = orbclient::Color::rgb(0x34, 0x34, 0x34);
     let font_color = Color::rgb(0xFF, 0xFF, 0xFF);
+    let cursor_color = Color::rgb(0xFF, 0xFF, 0xFF);
+    let selection_color = Color::rgba(0xFF, 0xFF, 0xFF, 0x33);
 
     editor.shape_as_needed(true);
     if editor.buffer().redraw() {
@@ -22,9 +24,15 @@ fn redraw(
 
         window.set(bg_color);
 
-        editor.draw(swash_cache, font_color, |x, y, w, h, color| {
-            window.rect(x, y, w, h, orbclient::Color { data: color.0 });
-        });
+        editor.draw(
+            swash_cache,
+            font_color,
+            cursor_color,
+            selection_color,
+            |x, y, w, h, color| {
+                window.rect(x, y, w, h, orbclient::Color { data: color.0 });
+            },
+        );
 
         window.sync();
 

--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -19,7 +19,7 @@ fn redraw(
     let selection_color = Color::rgba(0xFF, 0xFF, 0xFF, 0x33);
 
     editor.shape_as_needed(true);
-    if editor.buffer().redraw() {
+    if editor.redraw() {
         let instant = Instant::now();
 
         window.set(bg_color);
@@ -36,7 +36,7 @@ fn redraw(
 
         window.sync();
 
-        editor.buffer_mut().set_redraw(false);
+        editor.set_redraw(false);
 
         let duration = instant.elapsed();
         log::debug!("redraw: {:?}", duration);
@@ -159,13 +159,15 @@ fn main() {
     log::info!("Test completed in {:?}", test_elapsed);
 
     let mut wrong = 0;
-    for (line_i, line) in text.lines().enumerate() {
-        let buffer_line = &editor.buffer().lines[line_i];
-        if buffer_line.text() != line {
-            log::error!("line {}: {:?} != {:?}", line_i, buffer_line.text(), line);
-            wrong += 1;
+    editor.with_buffer(|buffer| {
+        for (line_i, line) in text.lines().enumerate() {
+            let buffer_line = &buffer.lines[line_i];
+            if buffer_line.text() != line {
+                log::error!("line {}: {:?} != {:?}", line_i, buffer_line.text(), line);
+                wrong += 1;
+            }
         }
-    }
+    });
     if wrong == 0 {
         log::info!("All lines matched!");
         process::exit(0);

--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -16,7 +16,7 @@ fn redraw(
     let bg_color = orbclient::Color::rgb(0x34, 0x34, 0x34);
     let font_color = Color::rgb(0xFF, 0xFF, 0xFF);
 
-    editor.shape_as_needed();
+    editor.shape_as_needed(true);
     if editor.buffer().redraw() {
         let instant = Instant::now();
 

--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -2,7 +2,7 @@
 
 use cosmic_text::{
     Action, BidiParagraphs, BorrowedWithFontSystem, Buffer, Color, Edit, Editor, FontSystem,
-    Metrics, SwashCache,
+    Metrics, Motion, SwashCache,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{env, fs, process, time::Instant};
@@ -106,7 +106,7 @@ fn main() {
             // Test delete of EGC
             {
                 let cursor = editor.cursor();
-                editor.action(Action::Previous);
+                editor.action(Action::Motion(Motion::Previous));
                 editor.action(Action::Delete);
                 for c in grapheme.chars() {
                     editor.action(Action::Insert(c));
@@ -130,7 +130,7 @@ fn main() {
         {
             let cursor = editor.cursor();
             editor.action(Action::Enter);
-            editor.action(Action::Previous);
+            editor.action(Action::Motion(Motion::Previous));
             editor.action(Action::Delete);
             assert_eq!(cursor, editor.cursor());
         }

--- a/examples/multiview/Cargo.toml
+++ b/examples/multiview/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "multiview"
+version = "0.1.0"
+authors = ["Jeremy Soller <jeremy@system76.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+cosmic-text = { path = "../.." }
+env_logger = "0.10"
+fontdb = "0.13"
+log = "0.4"
+softbuffer = "0.4"
+tiny-skia = "0.11"
+unicode-segmentation = "1.7"
+winit = "0.29"

--- a/examples/multiview/src/main.rs
+++ b/examples/multiview/src/main.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cosmic_text::{Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, Shaping, SwashCache};
+use cosmic_text::{
+    Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, Scroll, Shaping, SwashCache,
+};
 use std::{collections::HashMap, env, fs, num::NonZeroU32, rc::Rc, slice};
 use tiny_skia::{Color, Paint, PixmapMut, Rect, Transform};
 use winit::{
@@ -41,7 +43,7 @@ fn main() {
         window: Rc<WinitWindow>,
         context: softbuffer::Context<Rc<WinitWindow>>,
         surface: softbuffer::Surface<Rc<WinitWindow>, Rc<WinitWindow>>,
-        scroll: i32,
+        scroll: Scroll,
     }
     let mut windows = HashMap::new();
     for _ in 0..2 {
@@ -54,7 +56,7 @@ fn main() {
                 window,
                 context,
                 surface,
-                scroll: 0,
+                scroll: Scroll::default(),
             },
         );
     }
@@ -102,7 +104,8 @@ fn main() {
                         // Set size, will relayout and shape until scroll if changed
                         buffer.set_size(width as f32, height as f32);
                         // Shape until scroll, ensures scroll is clamped
-                        buffer.shape_until_scroll();
+                        //TODO: ability to prune with multiple views?
+                        buffer.shape_until_scroll(true);
                         // Update scroll after buffer clamps it
                         *scroll = buffer.scroll();
 
@@ -145,16 +148,16 @@ fn main() {
                         if state == ElementState::Pressed {
                             match logical_key {
                                 Key::Named(NamedKey::ArrowDown) => {
-                                    *scroll += 1;
+                                    scroll.layout += 1;
                                 }
                                 Key::Named(NamedKey::ArrowUp) => {
-                                    *scroll -= 1;
+                                    scroll.layout -= 1;
                                 }
                                 Key::Named(NamedKey::PageDown) => {
-                                    *scroll += buffer.visible_lines();
+                                    scroll.layout += buffer.visible_lines();
                                 }
                                 Key::Named(NamedKey::PageUp) => {
-                                    *scroll -= buffer.visible_lines();
+                                    scroll.layout -= buffer.visible_lines();
                                 }
                                 _ => {}
                             }

--- a/examples/multiview/src/main.rs
+++ b/examples/multiview/src/main.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use cosmic_text::{Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, Shaping, SwashCache};
+use std::{collections::HashMap, env, fs, num::NonZeroU32, rc::Rc, slice};
+use tiny_skia::{Color, Paint, PixmapMut, Rect, Transform};
+use winit::{
+    event::{ElementState, Event, KeyEvent, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    keyboard::{Key, NamedKey},
+    window::{Window as WinitWindow, WindowBuilder},
+};
+
+fn main() {
+    env_logger::init();
+
+    let path = if let Some(arg) = env::args().nth(1) {
+        arg
+    } else {
+        "sample/hello.txt".to_string()
+    };
+
+    let mut font_system = FontSystem::new();
+
+    let mut swash_cache = SwashCache::new();
+
+    let mut buffer = Buffer::new_empty(Metrics::new(14.0, 20.0));
+
+    let mut buffer = buffer.borrow_with(&mut font_system);
+
+    let attrs = Attrs::new().family(Family::Monospace);
+    match fs::read_to_string(&path) {
+        Ok(text) => buffer.set_text(&text, attrs, Shaping::Advanced),
+        Err(err) => {
+            log::error!("failed to load {:?}: {}", path, err);
+        }
+    }
+
+    let event_loop = EventLoop::new().unwrap();
+
+    struct Window {
+        window: Rc<WinitWindow>,
+        context: softbuffer::Context<Rc<WinitWindow>>,
+        surface: softbuffer::Surface<Rc<WinitWindow>, Rc<WinitWindow>>,
+        scroll: i32,
+    }
+    let mut windows = HashMap::new();
+    for _ in 0..2 {
+        let window = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
+        let context = softbuffer::Context::new(window.clone()).unwrap();
+        let surface = softbuffer::Surface::new(&context, window.clone()).unwrap();
+        windows.insert(
+            window.id(),
+            Window {
+                window,
+                context,
+                surface,
+                scroll: 0,
+            },
+        );
+    }
+
+    event_loop
+        .run(move |event, elwt| {
+            elwt.set_control_flow(ControlFlow::Wait);
+
+            match event {
+                Event::WindowEvent {
+                    window_id,
+                    event: WindowEvent::RedrawRequested,
+                } => {
+                    if let Some(Window {
+                        window,
+                        surface,
+                        scroll,
+                        ..
+                    }) = windows.get_mut(&window_id)
+                    {
+                        let (width, height) = {
+                            let size = window.inner_size();
+                            (size.width, size.height)
+                        };
+                        surface
+                            .resize(
+                                NonZeroU32::new(width).unwrap(),
+                                NonZeroU32::new(height).unwrap(),
+                            )
+                            .unwrap();
+
+                        let mut surface_buffer = surface.buffer_mut().unwrap();
+                        let surface_buffer_u8 = unsafe {
+                            slice::from_raw_parts_mut(
+                                surface_buffer.as_mut_ptr() as *mut u8,
+                                surface_buffer.len() * 4,
+                            )
+                        };
+                        let mut pixmap =
+                            PixmapMut::from_bytes(surface_buffer_u8, width, height).unwrap();
+                        pixmap.fill(Color::from_rgba8(0, 0, 0, 0xFF));
+
+                        // Set scroll to view scroll
+                        buffer.set_scroll(*scroll);
+                        // Set size, will relayout and shape until scroll if changed
+                        buffer.set_size(width as f32, height as f32);
+                        // Shape until scroll, ensures scroll is clamped
+                        buffer.shape_until_scroll();
+                        // Update scroll after buffer clamps it
+                        *scroll = buffer.scroll();
+
+                        let mut paint = Paint::default();
+                        paint.anti_alias = false;
+                        let transform = Transform::identity();
+                        buffer.draw(
+                            &mut swash_cache,
+                            cosmic_text::Color::rgb(0xFF, 0xFF, 0xFF),
+                            |x, y, w, h, color| {
+                                paint.set_color_rgba8(color.r(), color.g(), color.b(), color.a());
+                                pixmap.fill_rect(
+                                    Rect::from_xywh(x as f32, y as f32, w as f32, h as f32)
+                                        .unwrap(),
+                                    &paint,
+                                    transform,
+                                    None,
+                                );
+                            },
+                        );
+
+                        surface_buffer.present().unwrap();
+                    }
+                }
+                Event::WindowEvent {
+                    event:
+                        WindowEvent::KeyboardInput {
+                            event:
+                                KeyEvent {
+                                    logical_key,
+                                    text,
+                                    state,
+                                    ..
+                                },
+                            ..
+                        },
+                    window_id,
+                } => {
+                    if let Some(Window { window, scroll, .. }) = windows.get_mut(&window_id) {
+                        if state == ElementState::Pressed {
+                            match logical_key {
+                                Key::Named(NamedKey::ArrowDown) => {
+                                    *scroll += 1;
+                                }
+                                Key::Named(NamedKey::ArrowUp) => {
+                                    *scroll -= 1;
+                                }
+                                Key::Named(NamedKey::PageDown) => {
+                                    *scroll += buffer.visible_lines();
+                                }
+                                Key::Named(NamedKey::PageUp) => {
+                                    *scroll -= buffer.visible_lines();
+                                }
+                                _ => {}
+                            }
+                        }
+                        println!("{:?} {:?} {:?}", logical_key, text, state);
+                        window.request_redraw();
+                    }
+                }
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    window_id: _,
+                } => {
+                    //TODO: just close one window
+                    elwt.exit();
+                }
+                _ => {}
+            }
+        })
+        .unwrap();
+}

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, Buffer, Color, Edit, Editor, Family, FontSystem, Metrics, Motion, Shaping,
-    Style, SwashCache, Weight,
+    Action, Attrs, Buffer, CacheKeyFlags, Color, Edit, Editor, Family, FontSystem, Metrics, Motion,
+    Shaping, Style, SwashCache, Weight,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{
@@ -63,6 +63,10 @@ fn main() {
         ("Sans-Serif Normal ", attrs),
         ("Sans-Serif Bold ", attrs.weight(Weight::BOLD)),
         ("Sans-Serif Italic ", attrs.style(Style::Italic)),
+        (
+            "Sans-Serif Fake Italic ",
+            attrs.cache_key_flags(CacheKeyFlags::FAKE_ITALIC),
+        ),
         (
             "Sans-Serif Bold Italic\n",
             attrs.weight(Weight::BOLD).style(Style::Italic),

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, Buffer, Color, Edit, Editor, Family, FontSystem, Metrics, Shaping, Style,
-    SwashCache, Weight,
+    Action, Attrs, Buffer, Color, Edit, Editor, Family, FontSystem, Metrics, Motion, Shaping,
+    Style, SwashCache, Weight,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{
@@ -152,14 +152,26 @@ fn main() {
         for event in window.events() {
             match event.to_option() {
                 EventOption::Key(event) => match event.scancode {
-                    orbclient::K_LEFT if event.pressed => editor.action(Action::Left),
-                    orbclient::K_RIGHT if event.pressed => editor.action(Action::Right),
-                    orbclient::K_UP if event.pressed => editor.action(Action::Up),
-                    orbclient::K_DOWN if event.pressed => editor.action(Action::Down),
-                    orbclient::K_HOME if event.pressed => editor.action(Action::Home),
-                    orbclient::K_END if event.pressed => editor.action(Action::End),
-                    orbclient::K_PGUP if event.pressed => editor.action(Action::PageUp),
-                    orbclient::K_PGDN if event.pressed => editor.action(Action::PageDown),
+                    orbclient::K_LEFT if event.pressed => {
+                        editor.action(Action::Motion(Motion::Left))
+                    }
+                    orbclient::K_RIGHT if event.pressed => {
+                        editor.action(Action::Motion(Motion::Right))
+                    }
+                    orbclient::K_UP if event.pressed => editor.action(Action::Motion(Motion::Up)),
+                    orbclient::K_DOWN if event.pressed => {
+                        editor.action(Action::Motion(Motion::Down))
+                    }
+                    orbclient::K_HOME if event.pressed => {
+                        editor.action(Action::Motion(Motion::Home))
+                    }
+                    orbclient::K_END if event.pressed => editor.action(Action::Motion(Motion::End)),
+                    orbclient::K_PGUP if event.pressed => {
+                        editor.action(Action::Motion(Motion::PageUp))
+                    }
+                    orbclient::K_PGDN if event.pressed => {
+                        editor.action(Action::Motion(Motion::PageDown))
+                    }
                     orbclient::K_ENTER if event.pressed => editor.action(Action::Enter),
                     orbclient::K_BKSP if event.pressed => editor.action(Action::Backspace),
                     orbclient::K_DEL if event.pressed => editor.action(Action::Delete),

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -42,9 +42,7 @@ fn main() {
 
     let mut editor = editor.borrow_with(&mut font_system);
 
-    editor
-        .buffer_mut()
-        .set_size(window.width() as f32, window.height() as f32);
+    editor.with_buffer_mut(|buffer| buffer.set_size(window.width() as f32, window.height() as f32));
 
     let attrs = Attrs::new();
     let serif_attrs = attrs.family(Family::Serif);
@@ -117,9 +115,9 @@ fn main() {
         ),
     ];
 
-    editor
-        .buffer_mut()
-        .set_rich_text(spans.iter().copied(), attrs, Shaping::Advanced);
+    editor.with_buffer_mut(|buffer| {
+        buffer.set_rich_text(spans.iter().copied(), attrs, Shaping::Advanced)
+    });
 
     let mut swash_cache = SwashCache::new();
 
@@ -134,7 +132,7 @@ fn main() {
         let selection_color = Color::rgba(0xFF, 0xFF, 0xFF, 0x33);
 
         editor.shape_as_needed(true);
-        if editor.buffer().redraw() {
+        if editor.redraw() {
             let instant = Instant::now();
 
             window.set(bg_color);
@@ -151,7 +149,7 @@ fn main() {
 
             window.sync();
 
-            editor.buffer_mut().set_redraw(false);
+            editor.set_redraw(false);
 
             let duration = instant.elapsed();
             log::debug!("redraw: {:?}", duration);
@@ -206,9 +204,9 @@ fn main() {
                     }
                 }
                 EventOption::Resize(resize) => {
-                    editor
-                        .buffer_mut()
-                        .set_size(resize.width as f32, resize.height as f32);
+                    editor.with_buffer_mut(|buffer| {
+                        buffer.set_size(resize.width as f32, resize.height as f32)
+                    });
                 }
                 EventOption::Quit(_) => process::exit(0),
                 _ => (),

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -130,6 +130,8 @@ fn main() {
     loop {
         let bg_color = orbclient::Color::rgb(0x34, 0x34, 0x34);
         let font_color = Color::rgb(0xFF, 0xFF, 0xFF);
+        let cursor_color = Color::rgb(0xFF, 0xFF, 0xFF);
+        let selection_color = Color::rgba(0xFF, 0xFF, 0xFF, 0x33);
 
         editor.shape_as_needed(true);
         if editor.buffer().redraw() {
@@ -137,9 +139,15 @@ fn main() {
 
             window.set(bg_color);
 
-            editor.draw(&mut swash_cache, font_color, |x, y, w, h, color| {
-                window.rect(x, y, w, h, orbclient::Color { data: color.0 });
-            });
+            editor.draw(
+                &mut swash_cache,
+                font_color,
+                cursor_color,
+                selection_color,
+                |x, y, w, h, color| {
+                    window.rect(x, y, w, h, orbclient::Color { data: color.0 });
+                },
+            );
 
             window.sync();
 

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -131,7 +131,7 @@ fn main() {
         let bg_color = orbclient::Color::rgb(0x34, 0x34, 0x34);
         let font_color = Color::rgb(0xFF, 0xFF, 0xFF);
 
-        editor.shape_as_needed();
+        editor.shape_as_needed(true);
         if editor.buffer().redraw() {
             let instant = Instant::now();
 

--- a/examples/terminal/src/main.rs
+++ b/examples/terminal/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     buffer.set_text(&text, attrs, Shaping::Advanced);
 
     // Perform shaping as desired
-    buffer.shape_until_scroll();
+    buffer.shape_until_scroll(true);
 
     // Default text color (0xFF, 0xFF, 0xFF is white)
     const TEXT_COLOR: Color = Color::rgb(0xFF, 0xFF, 0xFF);

--- a/multiview.sh
+++ b/multiview.sh
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+RUST_LOG="cosmic_text=debug,multiview=debug" cargo run --release --package multiview -- "$@"

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -177,7 +177,8 @@ impl<'a> Attrs<'a> {
         //TODO: smarter way of including emoji
         face.post_script_name.contains("Emoji")
             || (face.style == self.style
-                && face.weight == self.weight
+                // Relax exact weight matching for the Monospace fallback use-case
+                && face.weight <= self.weight
                 && face.stretch == self.stretch)
     }
 

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -6,9 +6,11 @@ use alloc::{
     vec::Vec,
 };
 use core::ops::Range;
+use rangemap::RangeMap;
+
+use crate::CacheKeyFlags;
 
 pub use fontdb::{Family, Stretch, Style, Weight};
-use rangemap::RangeMap;
 
 /// Text color
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, Eq, Hash, PartialEq)]
@@ -109,6 +111,7 @@ pub struct Attrs<'a> {
     pub style: Style,
     pub weight: Weight,
     pub metadata: usize,
+    pub cache_key_flags: CacheKeyFlags,
 }
 
 impl<'a> Attrs<'a> {
@@ -123,6 +126,7 @@ impl<'a> Attrs<'a> {
             style: Style::Normal,
             weight: Weight::NORMAL,
             metadata: 0,
+            cache_key_flags: CacheKeyFlags::empty(),
         }
     }
 
@@ -162,6 +166,12 @@ impl<'a> Attrs<'a> {
         self
     }
 
+    /// Set [`CacheKeyFlags`]
+    pub fn cache_key_flags(mut self, cache_key_flags: CacheKeyFlags) -> Self {
+        self.cache_key_flags = cache_key_flags;
+        self
+    }
+
     /// Check if font matches
     pub fn matches(&self, face: &fontdb::FaceInfo) -> bool {
         //TODO: smarter way of including emoji
@@ -190,6 +200,7 @@ pub struct AttrsOwned {
     pub style: Style,
     pub weight: Weight,
     pub metadata: usize,
+    pub cache_key_flags: CacheKeyFlags,
 }
 
 impl AttrsOwned {
@@ -201,6 +212,7 @@ impl AttrsOwned {
             style: attrs.style,
             weight: attrs.weight,
             metadata: attrs.metadata,
+            cache_key_flags: attrs.cache_key_flags,
         }
     }
 
@@ -212,6 +224,7 @@ impl AttrsOwned {
             style: self.style,
             weight: self.weight,
             metadata: self.metadata,
+            cache_key_flags: self.cache_key_flags,
         }
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -237,6 +237,21 @@ pub struct Buffer {
     scratch: ShapeBuffer,
 }
 
+impl Clone for Buffer {
+    fn clone(&self) -> Self {
+        Self {
+            lines: self.lines.clone(),
+            metrics: self.metrics,
+            width: self.width,
+            height: self.height,
+            scroll: self.scroll,
+            redraw: self.redraw,
+            wrap: self.wrap,
+            scratch: ShapeBuffer::default(),
+        }
+    }
+}
+
 impl Buffer {
     /// Create an empty [`Buffer`] with the provided [`Metrics`].
     /// This is useful for initializing a [`Buffer`] without a [`FontSystem`].

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -534,7 +534,11 @@ impl Buffer {
     }
 
     /// Set monospace width monospace glyphs should be resized to match. `None` means don't resize
-    pub fn set_monospace_width(&mut self, font_system: &mut FontSystem, monospace_width: Option<f32>) {
+    pub fn set_monospace_width(
+        &mut self,
+        font_system: &mut FontSystem,
+        monospace_width: Option<f32>,
+    ) {
         if monospace_width != self.monospace_width {
             self.monospace_width = monospace_width;
             self.relayout(font_system);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -232,6 +232,7 @@ pub struct Buffer {
     /// True if a redraw is requires. Set to false after processing
     redraw: bool,
     wrap: Wrap,
+    monospace_width: Option<f32>,
 
     /// Scratch buffer for shaping and laying out.
     scratch: ShapeBuffer,
@@ -247,6 +248,7 @@ impl Clone for Buffer {
             scroll: self.scroll,
             redraw: self.redraw,
             wrap: self.wrap,
+            monospace_width: self.monospace_width,
             scratch: ShapeBuffer::default(),
         }
     }
@@ -275,6 +277,7 @@ impl Buffer {
             redraw: false,
             wrap: Wrap::Word,
             scratch: ShapeBuffer::default(),
+            monospace_width: None,
         }
     }
 
@@ -313,6 +316,7 @@ impl Buffer {
                     self.metrics.font_size,
                     self.width,
                     self.wrap,
+                    self.monospace_width,
                 );
             }
         }
@@ -492,6 +496,7 @@ impl Buffer {
             self.metrics.font_size,
             self.width,
             self.wrap,
+            self.monospace_width,
         ))
     }
 
@@ -518,6 +523,20 @@ impl Buffer {
     pub fn set_wrap(&mut self, font_system: &mut FontSystem, wrap: Wrap) {
         if wrap != self.wrap {
             self.wrap = wrap;
+            self.relayout(font_system);
+            self.shape_until_scroll(font_system, false);
+        }
+    }
+
+    /// Get the current `monospace_width`
+    pub fn monospace_width(&self) -> Option<f32> {
+        self.monospace_width
+    }
+
+    /// Set monospace width monospace glyphs should be resized to match. `None` means don't resize
+    pub fn set_monospace_width(&mut self, font_system: &mut FontSystem, monospace_width: Option<f32>) {
+        if monospace_width != self.monospace_width {
+            self.monospace_width = monospace_width;
             self.relayout(font_system);
             self.shape_until_scroll(font_system, false);
         }

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -9,7 +9,6 @@ pub struct BufferLine {
     //TODO: make this not pub(crate)
     text: String,
     attrs_list: AttrsList,
-    wrap: Wrap,
     align: Option<Align>,
     shape_opt: Option<ShapeLine>,
     layout_opt: Option<Vec<LayoutLine>>,
@@ -24,7 +23,6 @@ impl BufferLine {
         Self {
             text: text.into(),
             attrs_list,
-            wrap: Wrap::Word,
             align: None,
             shape_opt: None,
             layout_opt: None,
@@ -72,25 +70,6 @@ impl BufferLine {
         if attrs_list != self.attrs_list {
             self.attrs_list = attrs_list;
             self.reset();
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Get wrapping setting (wrap by characters/words or no wrapping)
-    pub fn wrap(&self) -> Wrap {
-        self.wrap
-    }
-
-    /// Set wrapping setting (wrap by characters/words or no wrapping)
-    ///
-    /// Will reset shape and layout if it differs from current wrapping setting.
-    /// Returns true if the line was reset
-    pub fn set_wrap(&mut self, wrap: Wrap) -> bool {
-        if wrap != self.wrap {
-            self.wrap = wrap;
-            self.reset_layout();
             true
         } else {
             false
@@ -146,7 +125,7 @@ impl BufferLine {
         self.reset();
 
         let mut new = Self::new(text, attrs_list, self.shaping);
-        new.wrap = self.wrap;
+        new.align = self.align;
         new
     }
 
@@ -223,7 +202,6 @@ impl BufferLine {
         wrap: Wrap,
     ) -> &[LayoutLine] {
         if self.layout_opt.is_none() {
-            self.wrap = wrap;
             let align = self.align;
             let shape = self.shape_in_buffer(scratch, font_system);
             let mut layout = Vec::with_capacity(1);

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -4,7 +4,7 @@ use alloc::{string::String, vec::Vec};
 use crate::{Align, AttrsList, FontSystem, LayoutLine, ShapeBuffer, ShapeLine, Shaping, Wrap};
 
 /// A line (or paragraph) of text that is shaped and laid out
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BufferLine {
     //TODO: make this not pub(crate)
     text: String,

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -210,7 +210,15 @@ impl BufferLine {
             let align = self.align;
             let shape = self.shape_in_buffer(scratch, font_system);
             let mut layout = Vec::with_capacity(1);
-            shape.layout_to_buffer(scratch, font_size, width, wrap, align, &mut layout, match_mono_width);
+            shape.layout_to_buffer(
+                scratch,
+                font_size,
+                width,
+                wrap,
+                align,
+                &mut layout,
+                match_mono_width,
+            );
             self.layout_opt = Some(layout);
         }
         self.layout_opt.as_ref().expect("layout not found")

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -172,7 +172,7 @@ impl BufferLine {
         self.shape_in_buffer(&mut ShapeBuffer::default(), font_system)
     }
 
-    /// Shape a line using a pre-existing shape buffer.
+    /// Shape a line using a pre-existing shape buffer, will cache results
     pub fn shape_in_buffer(
         &mut self,
         scratch: &mut ShapeBuffer,
@@ -204,17 +204,16 @@ impl BufferLine {
         width: f32,
         wrap: Wrap,
     ) -> &[LayoutLine] {
-        if self.layout_opt.is_none() {
-            self.wrap = wrap;
-            let align = self.align;
-            let shape = self.shape(font_system);
-            let layout = shape.layout(font_size, width, wrap, align);
-            self.layout_opt = Some(layout);
-        }
-        self.layout_opt.as_ref().expect("layout not found")
+        self.layout_in_buffer(
+            &mut ShapeBuffer::default(),
+            font_system,
+            font_size,
+            width,
+            wrap,
+        )
     }
 
-    /// Layout a line using a pre-existing shape buffer.
+    /// Layout a line using a pre-existing shape buffer, will cache results
     pub fn layout_in_buffer(
         &mut self,
         scratch: &mut ShapeBuffer,

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -13,6 +13,7 @@ pub struct BufferLine {
     shape_opt: Option<ShapeLine>,
     layout_opt: Option<Vec<LayoutLine>>,
     shaping: Shaping,
+    metadata: Option<usize>,
 }
 
 impl BufferLine {
@@ -27,6 +28,7 @@ impl BufferLine {
             shape_opt: None,
             layout_opt: None,
             shaping,
+            metadata: None,
         }
     }
 
@@ -69,7 +71,7 @@ impl BufferLine {
     pub fn set_attrs_list(&mut self, attrs_list: AttrsList) -> bool {
         if attrs_list != self.attrs_list {
             self.attrs_list = attrs_list;
-            self.reset();
+            self.reset_shaping();
             true
         } else {
             false
@@ -129,21 +131,21 @@ impl BufferLine {
         new
     }
 
-    /// Reset shaping and layout information
-    //TODO: make this private
+    /// Reset shaping, layout, and metadata caches
     pub fn reset(&mut self) {
-        self.shape_opt = None;
-        self.layout_opt = None;
+        self.metadata = None;
+        self.reset_shaping();
     }
 
-    /// Reset only layout information
+    /// Reset shaping and layout caches
+    pub fn reset_shaping(&mut self) {
+        self.shape_opt = None;
+        self.reset_layout();
+    }
+
+    /// Reset only layout cache
     pub fn reset_layout(&mut self) {
         self.layout_opt = None;
-    }
-
-    /// Check if shaping and layout information is cleared
-    pub fn is_reset(&self) -> bool {
-        self.shape_opt.is_none()
     }
 
     /// Shape line, will cache results
@@ -214,5 +216,16 @@ impl BufferLine {
     /// Get line layout cache
     pub fn layout_opt(&self) -> &Option<Vec<LayoutLine>> {
         &self.layout_opt
+    }
+
+    /// Get line metadata. This will be None if [`BufferLine::set_metadata`] has not been called
+    /// after the last reset of shaping and layout caches
+    pub fn metadata(&self) -> Option<usize> {
+        self.metadata
+    }
+
+    /// Set line metadata. This is stored until the next line reset
+    pub fn set_metadata(&mut self, metadata: usize) {
+        self.metadata = Some(metadata);
     }
 }

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -184,6 +184,7 @@ impl BufferLine {
         font_size: f32,
         width: f32,
         wrap: Wrap,
+        match_mono_width: Option<f32>,
     ) -> &[LayoutLine] {
         self.layout_in_buffer(
             &mut ShapeBuffer::default(),
@@ -191,6 +192,7 @@ impl BufferLine {
             font_size,
             width,
             wrap,
+            match_mono_width,
         )
     }
 
@@ -202,12 +204,13 @@ impl BufferLine {
         font_size: f32,
         width: f32,
         wrap: Wrap,
+        match_mono_width: Option<f32>,
     ) -> &[LayoutLine] {
         if self.layout_opt.is_none() {
             let align = self.align;
             let shape = self.shape_in_buffer(scratch, font_system);
             let mut layout = Vec::with_capacity(1);
-            shape.layout_to_buffer(scratch, font_size, width, wrap, align, &mut layout);
+            shape.layout_to_buffer(scratch, font_size, width, wrap, align, &mut layout, match_mono_width);
             self.layout_opt = Some(layout);
         }
         self.layout_opt.as_ref().expect("layout not found")

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -3,7 +3,7 @@ use crate::Color;
 /// Current cursor location
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Cursor {
-    /// Text line the cursor is on
+    /// Index of [`BufferLine`] in [`Buffer::lines`]
     pub line: usize,
     /// First-byte-index of glyph at cursor (will insert behind this glyph)
     pub index: usize,
@@ -81,8 +81,11 @@ impl Affinity {
 /// The position of a cursor within a [`Buffer`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LayoutCursor {
+    /// Index of [`BufferLine`] in [`Buffer::lines`]
     pub line: usize,
+    /// Index of [`LayoutLine`] in [`BufferLine::layout`]
     pub layout: usize,
+    /// Index of [`LayoutGlyph`] in [`LayoutLine::glyphs`]
     pub glyph: usize,
 }
 
@@ -144,4 +147,15 @@ pub enum Motion {
     BufferEnd,
     /// Move cursor to specific line
     GotoLine(usize),
+}
+
+/// Scroll position in [`Buffer`]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Scroll {
+    /// Index of [`BufferLine`] in [`Buffer::lines`]. This will be adjusted as needed if layout is
+    /// out of bounds
+    pub line: usize,
+    /// Index of [`LayoutLine`] in [`BufferLine::layout`]. This will be adjusted as needed
+    /// if it is negative or exceeds the number of layout lines
+    pub layout: i32,
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -91,7 +91,7 @@ pub struct LayoutCursor {
 
 impl LayoutCursor {
     /// Create a new [`LayoutCursor`]
-    pub fn new(line: usize, layout: usize, glyph: usize) -> Self {
+    pub const fn new(line: usize, layout: usize, glyph: usize) -> Self {
         Self {
             line,
             layout,
@@ -158,4 +158,11 @@ pub struct Scroll {
     /// Index of [`LayoutLine`] in [`BufferLine::layout`]. This will be adjusted as needed
     /// if it is negative or exceeds the number of layout lines
     pub layout: i32,
+}
+
+impl Scroll {
+    /// Create a new cursor
+    pub const fn new(line: usize, layout: i32) -> Self {
+        Self { line, layout }
+    }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,5 +1,3 @@
-use crate::Color;
-
 /// Current cursor location
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Cursor {
@@ -10,10 +8,6 @@ pub struct Cursor {
     /// Whether to associate the cursor with the run before it or the run after it if placed at the
     /// boundary between two runs
     pub affinity: Affinity,
-    /// Cached X position used for up and down movement
-    pub x_opt: Option<i32>,
-    /// Cursor color
-    pub color: Option<Color>,
 }
 
 impl Cursor {
@@ -28,18 +22,6 @@ impl Cursor {
             line,
             index,
             affinity,
-            x_opt: None,
-            color: None,
-        }
-    }
-    /// Create a new cursor, specifying the color
-    pub const fn new_with_color(line: usize, index: usize, color: Color) -> Self {
-        Self {
-            line,
-            index,
-            affinity: Affinity::Before,
-            x_opt: None,
-            color: Some(color),
         }
     }
 }
@@ -79,7 +61,7 @@ impl Affinity {
 }
 
 /// The position of a cursor within a [`Buffer`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct LayoutCursor {
     /// Index of [`BufferLine`] in [`Buffer::lines`]
     pub line: usize,
@@ -150,7 +132,7 @@ pub enum Motion {
 }
 
 /// Scroll position in [`Buffer`]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Scroll {
     /// Index of [`BufferLine`] in [`Buffer::lines`]. This will be adjusted as needed if layout is
     /// out of bounds

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -94,12 +94,13 @@ impl Edit for Editor {
         }
     }
 
-    fn shape_as_needed(&mut self, font_system: &mut FontSystem) {
+    fn shape_as_needed(&mut self, font_system: &mut FontSystem, prune: bool) {
         if self.cursor_moved {
-            self.buffer.shape_until_cursor(font_system, self.cursor);
+            self.buffer
+                .shape_until_cursor(font_system, self.cursor, prune);
             self.cursor_moved = false;
         } else {
-            self.buffer.shape_until_scroll(font_system);
+            self.buffer.shape_until_scroll(font_system, prune);
         }
     }
 
@@ -627,7 +628,7 @@ impl Edit for Editor {
             }
             Action::Scroll { lines } => {
                 let mut scroll = self.buffer.scroll();
-                scroll += lines;
+                scroll.layout += lines;
                 self.buffer.set_scroll(scroll);
             }
         }

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -2,6 +2,7 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
+use alloc::sync::Arc;
 use core::{cmp, iter::once};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -12,10 +13,35 @@ use crate::{
     Edit, FontSystem, Selection, Shaping,
 };
 
+#[derive(Debug)]
+pub enum BufferRef<'a> {
+    Owned(Buffer),
+    Borrowed(&'a mut Buffer),
+    Arc(Arc<Buffer>),
+}
+
+impl<'a> From<Buffer> for BufferRef<'a> {
+    fn from(buffer: Buffer) -> Self {
+        Self::Owned(buffer)
+    }
+}
+
+impl<'a> From<&'a mut Buffer> for BufferRef<'a> {
+    fn from(buffer: &'a mut Buffer) -> Self {
+        Self::Borrowed(buffer)
+    }
+}
+
+impl<'a> From<Arc<Buffer>> for BufferRef<'a> {
+    fn from(arc: Arc<Buffer>) -> Self {
+        Self::Arc(arc)
+    }
+}
+
 /// A wrapper of [`Buffer`] for easy editing
 #[derive(Debug)]
-pub struct Editor {
-    buffer: Buffer,
+pub struct Editor<'a> {
+    buffer_ref: BufferRef<'a>,
     cursor: Cursor,
     cursor_x_opt: Option<i32>,
     selection: Selection,
@@ -25,11 +51,11 @@ pub struct Editor {
     change: Option<Change>,
 }
 
-impl Editor {
+impl<'a> Editor<'a> {
     /// Create a new [`Editor`] with the provided [`Buffer`]
-    pub fn new(buffer: Buffer) -> Self {
+    pub fn new(buffer: impl Into<BufferRef<'a>>) -> Self {
         Self {
-            buffer,
+            buffer_ref: buffer.into(),
             cursor: Cursor::default(),
             cursor_x_opt: None,
             selection: Selection::None,
@@ -53,174 +79,187 @@ impl Editor {
     ) where
         F: FnMut(i32, i32, u32, u32, Color),
     {
-        let line_height = self.buffer.metrics().line_height;
+        self.with_buffer(|buffer| {
+            let line_height = buffer.metrics().line_height;
+            for run in buffer.layout_runs() {
+                let line_i = run.line_i;
+                let line_y = run.line_y;
+                let line_top = run.line_top;
 
-        for run in self.buffer.layout_runs() {
-            let line_i = run.line_i;
-            let line_y = run.line_y;
-            let line_top = run.line_top;
+                let cursor_glyph_opt = |cursor: &Cursor| -> Option<(usize, f32)> {
+                    if cursor.line == line_i {
+                        for (glyph_i, glyph) in run.glyphs.iter().enumerate() {
+                            if cursor.index == glyph.start {
+                                return Some((glyph_i, 0.0));
+                            } else if cursor.index > glyph.start && cursor.index < glyph.end {
+                                // Guess x offset based on characters
+                                let mut before = 0;
+                                let mut total = 0;
 
-            let cursor_glyph_opt = |cursor: &Cursor| -> Option<(usize, f32)> {
-                if cursor.line == line_i {
-                    for (glyph_i, glyph) in run.glyphs.iter().enumerate() {
-                        if cursor.index == glyph.start {
-                            return Some((glyph_i, 0.0));
-                        } else if cursor.index > glyph.start && cursor.index < glyph.end {
-                            // Guess x offset based on characters
-                            let mut before = 0;
-                            let mut total = 0;
-
-                            let cluster = &run.text[glyph.start..glyph.end];
-                            for (i, _) in cluster.grapheme_indices(true) {
-                                if glyph.start + i < cursor.index {
-                                    before += 1;
+                                let cluster = &run.text[glyph.start..glyph.end];
+                                for (i, _) in cluster.grapheme_indices(true) {
+                                    if glyph.start + i < cursor.index {
+                                        before += 1;
+                                    }
+                                    total += 1;
                                 }
-                                total += 1;
-                            }
 
-                            let offset = glyph.w * (before as f32) / (total as f32);
-                            return Some((glyph_i, offset));
+                                let offset = glyph.w * (before as f32) / (total as f32);
+                                return Some((glyph_i, offset));
+                            }
+                        }
+                        match run.glyphs.last() {
+                            Some(glyph) => {
+                                if cursor.index == glyph.end {
+                                    return Some((run.glyphs.len(), 0.0));
+                                }
+                            }
+                            None => {
+                                return Some((0, 0.0));
+                            }
                         }
                     }
-                    match run.glyphs.last() {
-                        Some(glyph) => {
-                            if cursor.index == glyph.end {
-                                return Some((run.glyphs.len(), 0.0));
+                    None
+                };
+
+                // Highlight selection (TODO: HIGHLIGHT COLOR!)
+                if let Some((start, end)) = self.selection_bounds() {
+                    if line_i >= start.line && line_i <= end.line {
+                        let mut range_opt = None;
+                        for glyph in run.glyphs.iter() {
+                            // Guess x offset based on characters
+                            let cluster = &run.text[glyph.start..glyph.end];
+                            let total = cluster.grapheme_indices(true).count();
+                            let mut c_x = glyph.x;
+                            let c_w = glyph.w / total as f32;
+                            for (i, c) in cluster.grapheme_indices(true) {
+                                let c_start = glyph.start + i;
+                                let c_end = glyph.start + i + c.len();
+                                if (start.line != line_i || c_end > start.index)
+                                    && (end.line != line_i || c_start < end.index)
+                                {
+                                    range_opt = match range_opt.take() {
+                                        Some((min, max)) => Some((
+                                            cmp::min(min, c_x as i32),
+                                            cmp::max(max, (c_x + c_w) as i32),
+                                        )),
+                                        None => Some((c_x as i32, (c_x + c_w) as i32)),
+                                    };
+                                } else if let Some((min, max)) = range_opt.take() {
+                                    f(
+                                        min,
+                                        line_top as i32,
+                                        cmp::max(0, max - min) as u32,
+                                        line_height as u32,
+                                        selection_color,
+                                    );
+                                }
+                                c_x += c_w;
                             }
                         }
-                        None => {
-                            return Some((0, 0.0));
+
+                        if run.glyphs.is_empty() && end.line > line_i {
+                            // Highlight all of internal empty lines
+                            range_opt = Some((0, buffer.size().0 as i32));
+                        }
+
+                        if let Some((mut min, mut max)) = range_opt.take() {
+                            if end.line > line_i {
+                                // Draw to end of line
+                                if run.rtl {
+                                    min = 0;
+                                } else {
+                                    max = buffer.size().0 as i32;
+                                }
+                            }
+                            f(
+                                min,
+                                line_top as i32,
+                                cmp::max(0, max - min) as u32,
+                                line_height as u32,
+                                selection_color,
+                            );
                         }
                     }
                 }
-                None
-            };
 
-            // Highlight selection (TODO: HIGHLIGHT COLOR!)
-            if let Some((start, end)) = self.selection_bounds() {
-                if line_i >= start.line && line_i <= end.line {
-                    let mut range_opt = None;
-                    for glyph in run.glyphs.iter() {
-                        // Guess x offset based on characters
-                        let cluster = &run.text[glyph.start..glyph.end];
-                        let total = cluster.grapheme_indices(true).count();
-                        let mut c_x = glyph.x;
-                        let c_w = glyph.w / total as f32;
-                        for (i, c) in cluster.grapheme_indices(true) {
-                            let c_start = glyph.start + i;
-                            let c_end = glyph.start + i + c.len();
-                            if (start.line != line_i || c_end > start.index)
-                                && (end.line != line_i || c_start < end.index)
-                            {
-                                range_opt = match range_opt.take() {
-                                    Some((min, max)) => Some((
-                                        cmp::min(min, c_x as i32),
-                                        cmp::max(max, (c_x + c_w) as i32),
-                                    )),
-                                    None => Some((c_x as i32, (c_x + c_w) as i32)),
-                                };
-                            } else if let Some((min, max)) = range_opt.take() {
-                                f(
-                                    min,
-                                    line_top as i32,
-                                    cmp::max(0, max - min) as u32,
-                                    line_height as u32,
-                                    selection_color,
-                                );
-                            }
-                            c_x += c_w;
-                        }
-                    }
-
-                    if run.glyphs.is_empty() && end.line > line_i {
-                        // Highlight all of internal empty lines
-                        range_opt = Some((0, self.buffer.size().0 as i32));
-                    }
-
-                    if let Some((mut min, mut max)) = range_opt.take() {
-                        if end.line > line_i {
-                            // Draw to end of line
-                            if run.rtl {
-                                min = 0;
-                            } else {
-                                max = self.buffer.size().0 as i32;
-                            }
-                        }
-                        f(
-                            min,
-                            line_top as i32,
-                            cmp::max(0, max - min) as u32,
-                            line_height as u32,
-                            selection_color,
-                        );
-                    }
-                }
-            }
-
-            // Draw cursor
-            if let Some((cursor_glyph, cursor_glyph_offset)) = cursor_glyph_opt(&self.cursor) {
-                let x = match run.glyphs.get(cursor_glyph) {
-                    Some(glyph) => {
-                        // Start of detected glyph
-                        if glyph.level.is_rtl() {
-                            (glyph.x + glyph.w - cursor_glyph_offset) as i32
-                        } else {
-                            (glyph.x + cursor_glyph_offset) as i32
-                        }
-                    }
-                    None => match run.glyphs.last() {
+                // Draw cursor
+                if let Some((cursor_glyph, cursor_glyph_offset)) = cursor_glyph_opt(&self.cursor) {
+                    let x = match run.glyphs.get(cursor_glyph) {
                         Some(glyph) => {
-                            // End of last glyph
+                            // Start of detected glyph
                             if glyph.level.is_rtl() {
-                                glyph.x as i32
+                                (glyph.x + glyph.w - cursor_glyph_offset) as i32
                             } else {
-                                (glyph.x + glyph.w) as i32
+                                (glyph.x + cursor_glyph_offset) as i32
                             }
                         }
-                        None => {
-                            // Start of empty line
-                            0
-                        }
-                    },
-                };
+                        None => match run.glyphs.last() {
+                            Some(glyph) => {
+                                // End of last glyph
+                                if glyph.level.is_rtl() {
+                                    glyph.x as i32
+                                } else {
+                                    (glyph.x + glyph.w) as i32
+                                }
+                            }
+                            None => {
+                                // Start of empty line
+                                0
+                            }
+                        },
+                    };
 
-                f(x, line_top as i32, 1, line_height as u32, cursor_color);
+                    f(x, line_top as i32, 1, line_height as u32, cursor_color);
+                }
+
+                for glyph in run.glyphs.iter() {
+                    let physical_glyph = glyph.physical((0., 0.), 1.0);
+
+                    let glyph_color = match glyph.color_opt {
+                        Some(some) => some,
+                        None => text_color,
+                    };
+
+                    cache.with_pixels(
+                        font_system,
+                        physical_glyph.cache_key,
+                        glyph_color,
+                        |x, y, color| {
+                            f(
+                                physical_glyph.x + x,
+                                line_y as i32 + physical_glyph.y + y,
+                                1,
+                                1,
+                                color,
+                            );
+                        },
+                    );
+                }
             }
-
-            for glyph in run.glyphs.iter() {
-                let physical_glyph = glyph.physical((0., 0.), 1.0);
-
-                let glyph_color = match glyph.color_opt {
-                    Some(some) => some,
-                    None => text_color,
-                };
-
-                cache.with_pixels(
-                    font_system,
-                    physical_glyph.cache_key,
-                    glyph_color,
-                    |x, y, color| {
-                        f(
-                            physical_glyph.x + x,
-                            line_y as i32 + physical_glyph.y + y,
-                            1,
-                            1,
-                            color,
-                        );
-                    },
-                );
-            }
-        }
+        });
     }
 }
 
-impl Edit for Editor {
-    fn buffer(&self) -> &Buffer {
-        &self.buffer
+impl<'a> Edit for Editor<'a> {
+    fn with_buffer<F: FnOnce(&Buffer) -> T, T>(&self, f: F) -> T {
+        match &self.buffer_ref {
+            BufferRef::Owned(buffer) => f(buffer),
+            BufferRef::Borrowed(buffer) => f(buffer),
+            BufferRef::Arc(buffer) => f(buffer),
+        }
     }
 
-    fn buffer_mut(&mut self) -> &mut Buffer {
-        &mut self.buffer
+    fn with_buffer_mut<F: FnOnce(&mut Buffer) -> T, T>(&mut self, f: F) -> T {
+        match &mut self.buffer_ref {
+            BufferRef::Owned(buffer) => f(buffer),
+            BufferRef::Borrowed(buffer) => f(buffer),
+            BufferRef::Arc(arc) => match Arc::get_mut(arc) {
+                Some(buffer) => f(buffer),
+                //TODO: use make_mut?
+                None => panic!("BufferRef::Arc cannot be accessed mutibly"),
+            },
+        }
     }
 
     fn cursor(&self) -> Cursor {
@@ -231,7 +270,7 @@ impl Edit for Editor {
         if self.cursor != cursor {
             self.cursor = cursor;
             self.cursor_moved = true;
-            self.buffer.set_redraw(true);
+            self.with_buffer_mut(|buffer| buffer.set_redraw(true));
         }
     }
 
@@ -242,7 +281,7 @@ impl Edit for Editor {
     fn set_selection(&mut self, selection: Selection) {
         if self.selection != selection {
             self.selection = selection;
-            self.buffer.set_redraw(true);
+            self.with_buffer_mut(|buffer| buffer.set_redraw(true));
         }
     }
 
@@ -265,76 +304,79 @@ impl Edit for Editor {
         }
         if self.tab_width != tab_width {
             self.tab_width = tab_width;
-            self.buffer.set_redraw(true);
+            self.with_buffer_mut(|buffer| buffer.set_redraw(true));
         }
     }
 
     fn shape_as_needed(&mut self, font_system: &mut FontSystem, prune: bool) {
         if self.cursor_moved {
-            self.buffer
-                .shape_until_cursor(font_system, self.cursor, prune);
+            let cursor = self.cursor;
+            self.with_buffer_mut(|buffer| buffer.shape_until_cursor(font_system, cursor, prune));
             self.cursor_moved = false;
         } else {
-            self.buffer.shape_until_scroll(font_system, prune);
+            self.with_buffer_mut(|buffer| buffer.shape_until_scroll(font_system, prune));
         }
     }
 
     fn delete_range(&mut self, start: Cursor, end: Cursor) {
-        // Collect removed data for change tracking
-        let mut change_text = String::new();
+        let change_item = self.with_buffer_mut(|buffer| {
+            // Collect removed data for change tracking
+            let mut change_text = String::new();
 
-        // Delete the selection from the last line
-        let end_line_opt = if end.line > start.line {
-            // Get part of line after selection
-            let after = self.buffer.lines[end.line].split_off(end.index);
+            // Delete the selection from the last line
+            let end_line_opt = if end.line > start.line {
+                // Get part of line after selection
+                let after = buffer.lines[end.line].split_off(end.index);
 
-            // Remove end line
-            let removed = self.buffer.lines.remove(end.line);
-            change_text.insert_str(0, removed.text());
+                // Remove end line
+                let removed = buffer.lines.remove(end.line);
+                change_text.insert_str(0, removed.text());
 
-            Some(after)
-        } else {
-            None
-        };
-
-        // Delete interior lines (in reverse for safety)
-        for line_i in (start.line + 1..end.line).rev() {
-            let removed = self.buffer.lines.remove(line_i);
-            change_text.insert_str(0, removed.text());
-        }
-
-        // Delete the selection from the first line
-        {
-            // Get part after selection if start line is also end line
-            let after_opt = if start.line == end.line {
-                Some(self.buffer.lines[start.line].split_off(end.index))
+                Some(after)
             } else {
                 None
             };
 
-            // Delete selected part of line
-            let removed = self.buffer.lines[start.line].split_off(start.index);
-            change_text.insert_str(0, removed.text());
-
-            // Re-add part of line after selection
-            if let Some(after) = after_opt {
-                self.buffer.lines[start.line].append(after);
+            // Delete interior lines (in reverse for safety)
+            for line_i in (start.line + 1..end.line).rev() {
+                let removed = buffer.lines.remove(line_i);
+                change_text.insert_str(0, removed.text());
             }
 
-            // Re-add valid parts of end line
-            if let Some(end_line) = end_line_opt {
-                self.buffer.lines[start.line].append(end_line);
-            }
-        }
+            // Delete the selection from the first line
+            {
+                // Get part after selection if start line is also end line
+                let after_opt = if start.line == end.line {
+                    Some(buffer.lines[start.line].split_off(end.index))
+                } else {
+                    None
+                };
 
-        if let Some(ref mut change) = self.change {
-            let item = ChangeItem {
+                // Delete selected part of line
+                let removed = buffer.lines[start.line].split_off(start.index);
+                change_text.insert_str(0, removed.text());
+
+                // Re-add part of line after selection
+                if let Some(after) = after_opt {
+                    buffer.lines[start.line].append(after);
+                }
+
+                // Re-add valid parts of end line
+                if let Some(end_line) = end_line_opt {
+                    buffer.lines[start.line].append(end_line);
+                }
+            }
+
+            ChangeItem {
                 start,
                 end,
                 text: change_text,
                 insert: false,
-            };
-            change.items.push(item);
+            }
+        });
+
+        if let Some(ref mut change) = self.change {
+            change.items.push(change_item);
         }
     }
 
@@ -349,80 +391,83 @@ impl Edit for Editor {
             return cursor;
         }
 
-        // Save cursor for change tracking
-        let start = cursor;
+        let change_item = self.with_buffer_mut(|buffer| {
+            // Save cursor for change tracking
+            let start = cursor;
 
-        let line: &mut BufferLine = &mut self.buffer.lines[cursor.line];
-        let insert_line = cursor.line + 1;
+            let line: &mut BufferLine = &mut buffer.lines[cursor.line];
+            let insert_line = cursor.line + 1;
 
-        // Collect text after insertion as a line
-        let after: BufferLine = line.split_off(cursor.index);
-        let after_len = after.text().len();
+            // Collect text after insertion as a line
+            let after: BufferLine = line.split_off(cursor.index);
+            let after_len = after.text().len();
 
-        // Collect attributes
-        let mut final_attrs = attrs_list.unwrap_or_else(|| {
-            AttrsList::new(line.attrs_list().get_span(cursor.index.saturating_sub(1)))
-        });
+            // Collect attributes
+            let mut final_attrs = attrs_list.unwrap_or_else(|| {
+                AttrsList::new(line.attrs_list().get_span(cursor.index.saturating_sub(1)))
+            });
 
-        // Append the inserted text, line by line
-        // we want to see a blank entry if the string ends with a newline
-        let addendum = once("").filter(|_| data.ends_with('\n'));
-        let mut lines_iter = data.split_inclusive('\n').chain(addendum);
-        if let Some(data_line) = lines_iter.next() {
-            let mut these_attrs = final_attrs.split_off(data_line.len());
-            remaining_split_len -= data_line.len();
-            core::mem::swap(&mut these_attrs, &mut final_attrs);
-            line.append(BufferLine::new(
-                data_line
-                    .strip_suffix(char::is_control)
-                    .unwrap_or(data_line),
-                these_attrs,
-                Shaping::Advanced,
-            ));
-        } else {
-            panic!("str::lines() did not yield any elements");
-        }
-        if let Some(data_line) = lines_iter.next_back() {
-            remaining_split_len -= data_line.len();
-            let mut tmp = BufferLine::new(
-                data_line
-                    .strip_suffix(char::is_control)
-                    .unwrap_or(data_line),
-                final_attrs.split_off(remaining_split_len),
-                Shaping::Advanced,
-            );
-            tmp.append(after);
-            self.buffer.lines.insert(insert_line, tmp);
-            cursor.line += 1;
-        } else {
-            line.append(after);
-        }
-        for data_line in lines_iter.rev() {
-            remaining_split_len -= data_line.len();
-            let tmp = BufferLine::new(
-                data_line
-                    .strip_suffix(char::is_control)
-                    .unwrap_or(data_line),
-                final_attrs.split_off(remaining_split_len),
-                Shaping::Advanced,
-            );
-            self.buffer.lines.insert(insert_line, tmp);
-            cursor.line += 1;
-        }
+            // Append the inserted text, line by line
+            // we want to see a blank entry if the string ends with a newline
+            let addendum = once("").filter(|_| data.ends_with('\n'));
+            let mut lines_iter = data.split_inclusive('\n').chain(addendum);
+            if let Some(data_line) = lines_iter.next() {
+                let mut these_attrs = final_attrs.split_off(data_line.len());
+                remaining_split_len -= data_line.len();
+                core::mem::swap(&mut these_attrs, &mut final_attrs);
+                line.append(BufferLine::new(
+                    data_line
+                        .strip_suffix(char::is_control)
+                        .unwrap_or(data_line),
+                    these_attrs,
+                    Shaping::Advanced,
+                ));
+            } else {
+                panic!("str::lines() did not yield any elements");
+            }
+            if let Some(data_line) = lines_iter.next_back() {
+                remaining_split_len -= data_line.len();
+                let mut tmp = BufferLine::new(
+                    data_line
+                        .strip_suffix(char::is_control)
+                        .unwrap_or(data_line),
+                    final_attrs.split_off(remaining_split_len),
+                    Shaping::Advanced,
+                );
+                tmp.append(after);
+                buffer.lines.insert(insert_line, tmp);
+                cursor.line += 1;
+            } else {
+                line.append(after);
+            }
+            for data_line in lines_iter.rev() {
+                remaining_split_len -= data_line.len();
+                let tmp = BufferLine::new(
+                    data_line
+                        .strip_suffix(char::is_control)
+                        .unwrap_or(data_line),
+                    final_attrs.split_off(remaining_split_len),
+                    Shaping::Advanced,
+                );
+                buffer.lines.insert(insert_line, tmp);
+                cursor.line += 1;
+            }
 
-        assert_eq!(remaining_split_len, 0);
+            assert_eq!(remaining_split_len, 0);
 
-        // Append the text after insertion
-        cursor.index = self.buffer.lines[cursor.line].text().len() - after_len;
+            // Append the text after insertion
+            cursor.index = buffer.lines[cursor.line].text().len() - after_len;
 
-        if let Some(ref mut change) = self.change {
-            let item = ChangeItem {
+            ChangeItem {
                 start,
                 end: cursor,
                 text: data.to_string(),
                 insert: true,
-            };
-            change.items.push(item);
+            }
+        });
+
+        if let Some(ref mut change) = self.change {
+            change.items.push(change_item);
         }
 
         cursor
@@ -430,32 +475,33 @@ impl Edit for Editor {
 
     fn copy_selection(&self) -> Option<String> {
         let (start, end) = self.selection_bounds()?;
+        self.with_buffer(|buffer| {
+            let mut selection = String::new();
+            // Take the selection from the first line
+            {
+                // Add selected part of line to string
+                if start.line == end.line {
+                    selection.push_str(&buffer.lines[start.line].text()[start.index..end.index]);
+                } else {
+                    selection.push_str(&buffer.lines[start.line].text()[start.index..]);
+                    selection.push('\n');
+                }
+            }
 
-        let mut selection = String::new();
-        // Take the selection from the first line
-        {
-            // Add selected part of line to string
-            if start.line == end.line {
-                selection.push_str(&self.buffer.lines[start.line].text()[start.index..end.index]);
-            } else {
-                selection.push_str(&self.buffer.lines[start.line].text()[start.index..]);
+            // Take the selection from all interior lines (if they exist)
+            for line_i in start.line + 1..end.line {
+                selection.push_str(buffer.lines[line_i].text());
                 selection.push('\n');
             }
-        }
 
-        // Take the selection from all interior lines (if they exist)
-        for line_i in start.line + 1..end.line {
-            selection.push_str(self.buffer.lines[line_i].text());
-            selection.push('\n');
-        }
+            // Take the selection from the last line
+            if end.line > start.line {
+                // Add selected part of line to string
+                selection.push_str(&buffer.lines[end.line].text()[..end.index]);
+            }
 
-        // Take the selection from the last line
-        if end.line > start.line {
-            // Add selected part of line to string
-            selection.push_str(&self.buffer.lines[end.line].text()[..end.index]);
-        }
-
-        Some(selection)
+            Some(selection)
+        })
     }
 
     fn delete_selection(&mut self) -> bool {
@@ -517,18 +563,19 @@ impl Edit for Editor {
 
         match action {
             Action::Motion(motion) => {
-                if let Some((cursor, cursor_x_opt)) =
-                    self.buffer
-                        .cursor_motion(font_system, self.cursor, self.cursor_x_opt, motion)
-                {
-                    self.cursor = cursor;
-                    self.cursor_x_opt = cursor_x_opt;
+                let cursor = self.cursor;
+                let cursor_x_opt = self.cursor_x_opt;
+                if let Some((new_cursor, new_cursor_x_opt)) = self.with_buffer_mut(|buffer| {
+                    buffer.cursor_motion(font_system, cursor, cursor_x_opt, motion)
+                }) {
+                    self.cursor = new_cursor;
+                    self.cursor_x_opt = new_cursor_x_opt;
                 }
             }
             Action::Escape => {
                 match self.selection {
                     Selection::None => {}
-                    _ => self.buffer.set_redraw(true),
+                    _ => self.with_buffer_mut(|buffer| buffer.set_redraw(true)),
                 }
                 self.selection = Selection::None;
             }
@@ -548,8 +595,8 @@ impl Edit for Editor {
                 //TODO: what about indenting more after opening brackets or parentheses?
                 if self.auto_indent {
                     let mut string = String::from("\n");
-                    {
-                        let line = &self.buffer.lines[self.cursor.line];
+                    self.with_buffer(|buffer| {
+                        let line = &buffer.lines[self.cursor.line];
                         let text = line.text();
                         for c in text.chars() {
                             if c.is_whitespace() {
@@ -558,14 +605,17 @@ impl Edit for Editor {
                                 break;
                             }
                         }
-                    }
+                    });
                     self.insert_string(&string, None);
                 } else {
                     self.insert_string("\n", None);
                 }
 
                 // Ensure line is properly shaped and laid out (for potential immediate commands)
-                self.buffer.line_layout(font_system, self.cursor.line);
+                let line_i = self.cursor.line;
+                self.with_buffer_mut(|buffer| {
+                    buffer.line_layout(font_system, line_i);
+                });
             }
             Action::Backspace => {
                 if self.delete_selection() {
@@ -576,16 +626,17 @@ impl Edit for Editor {
 
                     if self.cursor.index > 0 {
                         // Move cursor to previous character index
-                        let line = &self.buffer.lines[self.cursor.line];
-                        self.cursor.index = line.text()[..self.cursor.index]
-                            .char_indices()
-                            .next_back()
-                            .map_or(0, |(i, _)| i);
+                        self.cursor.index = self.with_buffer(|buffer| {
+                            buffer.lines[self.cursor.line].text()[..self.cursor.index]
+                                .char_indices()
+                                .next_back()
+                                .map_or(0, |(i, _)| i)
+                        });
                     } else if self.cursor.line > 0 {
                         // Move cursor to previous line
                         self.cursor.line -= 1;
-                        let line = &self.buffer.lines[self.cursor.line];
-                        self.cursor.index = line.text().len();
+                        self.cursor.index =
+                            self.with_buffer(|buffer| buffer.lines[self.cursor.line].text().len());
                     }
 
                     if self.cursor != end {
@@ -598,30 +649,34 @@ impl Edit for Editor {
                 if self.delete_selection() {
                     // Deleted selection
                 } else {
-                    // Save current cursor as end
+                    // Save current cursor as start and end
+                    let mut start = self.cursor;
                     let mut end = self.cursor;
 
-                    if self.cursor.index < self.buffer.lines[self.cursor.line].text().len() {
-                        let line = &self.buffer.lines[self.cursor.line];
+                    self.with_buffer(|buffer| {
+                        if start.index < buffer.lines[start.line].text().len() {
+                            let line = &buffer.lines[start.line];
 
-                        let range_opt = line
-                            .text()
-                            .grapheme_indices(true)
-                            .take_while(|(i, _)| *i <= self.cursor.index)
-                            .last()
-                            .map(|(i, c)| i..(i + c.len()));
+                            let range_opt = line
+                                .text()
+                                .grapheme_indices(true)
+                                .take_while(|(i, _)| *i <= start.index)
+                                .last()
+                                .map(|(i, c)| i..(i + c.len()));
 
-                        if let Some(range) = range_opt {
-                            self.cursor.index = range.start;
-                            end.index = range.end;
+                            if let Some(range) = range_opt {
+                                start.index = range.start;
+                                end.index = range.end;
+                            }
+                        } else if start.line + 1 < buffer.lines.len() {
+                            end.line += 1;
+                            end.index = 0;
                         }
-                    } else if self.cursor.line + 1 < self.buffer.lines.len() {
-                        end.line += 1;
-                        end.index = 0;
-                    }
+                    });
 
-                    if self.cursor != end {
-                        self.delete_range(self.cursor, end);
+                    if start != end {
+                        self.cursor = start;
+                        self.delete_range(start, end);
                     }
                 }
             }
@@ -636,10 +691,10 @@ impl Edit for Editor {
                 let tab_width: usize = self.tab_width.into();
                 for line_i in start.line..=end.line {
                     // Determine indexes of last indent and first character after whitespace
-                    let mut after_whitespace;
+                    let mut after_whitespace = 0;
                     let mut required_indent = 0;
-                    {
-                        let line = &self.buffer.lines[line_i];
+                    self.with_buffer(|buffer| {
+                        let line = &buffer.lines[line_i];
                         let text = line.text();
                         // Default to end of line if no non-whitespace found
                         after_whitespace = text.len();
@@ -650,7 +705,7 @@ impl Edit for Editor {
                                 break;
                             }
                         }
-                    }
+                    });
 
                     // No indent required (not possible?)
                     if required_indent == 0 {
@@ -685,7 +740,7 @@ impl Edit for Editor {
                     }
 
                     // Request redraw
-                    self.buffer.set_redraw(true);
+                    self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                 }
             }
             Action::Unindent => {
@@ -700,9 +755,9 @@ impl Edit for Editor {
                 for line_i in start.line..=end.line {
                     // Determine indexes of last indent and first character after whitespace
                     let mut last_indent = 0;
-                    let mut after_whitespace;
-                    {
-                        let line = &self.buffer.lines[line_i];
+                    let mut after_whitespace = 0;
+                    self.with_buffer(|buffer| {
+                        let line = &buffer.lines[line_i];
                         let text = line.text();
                         // Default to end of line if no non-whitespace found
                         after_whitespace = text.len();
@@ -715,7 +770,7 @@ impl Edit for Editor {
                                 last_indent = index;
                             }
                         }
-                    }
+                    });
 
                     // No de-indent required
                     if last_indent == after_whitespace {
@@ -746,65 +801,71 @@ impl Edit for Editor {
                     }
 
                     // Request redraw
-                    self.buffer.set_redraw(true);
+                    self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                 }
             }
             Action::Click { x, y } => {
                 self.set_selection(Selection::None);
 
-                if let Some(new_cursor) = self.buffer.hit(x as f32, y as f32) {
+                if let Some(new_cursor) = self.with_buffer(|buffer| buffer.hit(x as f32, y as f32))
+                {
                     if new_cursor != self.cursor {
                         self.cursor = new_cursor;
-                        self.buffer.set_redraw(true);
+                        self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                     }
                 }
             }
             Action::DoubleClick { x, y } => {
                 self.set_selection(Selection::None);
 
-                if let Some(new_cursor) = self.buffer.hit(x as f32, y as f32) {
+                if let Some(new_cursor) = self.with_buffer(|buffer| buffer.hit(x as f32, y as f32))
+                {
                     if new_cursor != self.cursor {
                         self.cursor = new_cursor;
-                        self.buffer.set_redraw(true);
+                        self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                     }
                     self.selection = Selection::Word(self.cursor);
-                    self.buffer.set_redraw(true);
+                    self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                 }
             }
             Action::TripleClick { x, y } => {
                 self.set_selection(Selection::None);
 
-                if let Some(new_cursor) = self.buffer.hit(x as f32, y as f32) {
+                if let Some(new_cursor) = self.with_buffer(|buffer| buffer.hit(x as f32, y as f32))
+                {
                     if new_cursor != self.cursor {
                         self.cursor = new_cursor;
                     }
                     self.selection = Selection::Line(self.cursor);
-                    self.buffer.set_redraw(true);
+                    self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                 }
             }
             Action::Drag { x, y } => {
                 if self.selection == Selection::None {
                     self.selection = Selection::Normal(self.cursor);
-                    self.buffer.set_redraw(true);
+                    self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                 }
 
-                if let Some(new_cursor) = self.buffer.hit(x as f32, y as f32) {
+                if let Some(new_cursor) = self.with_buffer(|buffer| buffer.hit(x as f32, y as f32))
+                {
                     if new_cursor != self.cursor {
                         self.cursor = new_cursor;
-                        self.buffer.set_redraw(true);
+                        self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                     }
                 }
             }
             Action::Scroll { lines } => {
-                let mut scroll = self.buffer.scroll();
-                scroll.layout += lines;
-                self.buffer.set_scroll(scroll);
+                self.with_buffer_mut(|buffer| {
+                    let mut scroll = buffer.scroll();
+                    scroll.layout += lines;
+                    buffer.set_scroll(scroll);
+                });
             }
         }
 
         if old_cursor != self.cursor {
             self.cursor_moved = true;
-            self.buffer.set_redraw(true);
+            self.with_buffer_mut(|buffer| buffer.set_redraw(true));
 
             /*TODO
             if let Some(glyph) = run.glyphs.get(new_cursor_glyph) {
@@ -825,7 +886,7 @@ impl Edit for Editor {
     }
 }
 
-impl<'a> BorrowedWithFontSystem<'a, Editor> {
+impl<'a, 'b> BorrowedWithFontSystem<'a, Editor<'b>> {
     #[cfg(feature = "swash")]
     pub fn draw<F>(
         &mut self,

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -17,7 +17,6 @@ use crate::{
 pub struct Editor {
     buffer: Buffer,
     cursor: Cursor,
-    cursor_x_opt: Option<i32>,
     selection: Selection,
     cursor_moved: bool,
     auto_indent: bool,
@@ -31,7 +30,6 @@ impl Editor {
         Self {
             buffer,
             cursor: Cursor::default(),
-            cursor_x_opt: None,
             selection: Selection::None,
             cursor_moved: false,
             auto_indent: false,
@@ -58,7 +56,6 @@ impl Edit for Editor {
         if self.cursor != cursor {
             self.cursor = cursor;
             self.cursor_moved = true;
-            self.cursor_x_opt = None;
             self.buffer.set_redraw(true);
         }
     }

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -231,7 +231,7 @@ pub trait Edit {
     fn set_tab_width(&mut self, tab_width: u16);
 
     /// Shape lines until scroll, after adjusting scroll if the cursor moved
-    fn shape_as_needed(&mut self, font_system: &mut FontSystem);
+    fn shape_as_needed(&mut self, font_system: &mut FontSystem, prune: bool);
 
     /// Delete text starting at start Cursor and ending at end Cursor
     fn delete_range(&mut self, start: Cursor, end: Cursor);
@@ -288,8 +288,8 @@ impl<'a, T: Edit> BorrowedWithFontSystem<'a, T> {
     }
 
     /// Shape lines until scroll, after adjusting scroll if the cursor moved
-    pub fn shape_as_needed(&mut self) {
-        self.inner.shape_as_needed(self.font_system);
+    pub fn shape_as_needed(&mut self, prune: bool) {
+        self.inner.shape_as_needed(self.font_system, prune);
     }
 
     /// Perform an [Action] on the editor

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -3,8 +3,6 @@ use alloc::{string::String, vec::Vec};
 use core::cmp;
 use unicode_segmentation::UnicodeSegmentation;
 
-#[cfg(feature = "swash")]
-use crate::Color;
 use crate::{AttrsList, BorrowedWithFontSystem, Buffer, Cursor, FontSystem, Motion};
 
 pub use self::editor::*;
@@ -265,17 +263,6 @@ pub trait Edit {
 
     /// Perform an [Action] on the editor
     fn action(&mut self, font_system: &mut FontSystem, action: Action);
-
-    /// Draw the editor
-    #[cfg(feature = "swash")]
-    fn draw<F>(
-        &self,
-        font_system: &mut FontSystem,
-        cache: &mut crate::SwashCache,
-        color: Color,
-        f: F,
-    ) where
-        F: FnMut(i32, i32, u32, u32, Color);
 }
 
 impl<'a, T: Edit> BorrowedWithFontSystem<'a, T> {
@@ -295,14 +282,5 @@ impl<'a, T: Edit> BorrowedWithFontSystem<'a, T> {
     /// Perform an [Action] on the editor
     pub fn action(&mut self, action: Action) {
         self.inner.action(self.font_system, action);
-    }
-
-    /// Draw the editor
-    #[cfg(feature = "swash")]
-    pub fn draw<F>(&mut self, cache: &mut crate::SwashCache, color: Color, f: F)
-    where
-        F: FnMut(i32, i32, u32, u32, Color),
-    {
-        self.inner.draw(self.font_system, cache, color, f);
     }
 }

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -5,7 +5,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 #[cfg(feature = "swash")]
 use crate::Color;
-use crate::{AttrsList, BorrowedWithFontSystem, Buffer, Cursor, FontSystem};
+use crate::{AttrsList, BorrowedWithFontSystem, Buffer, Cursor, FontSystem, Motion};
 
 pub use self::editor::*;
 mod editor;
@@ -23,34 +23,8 @@ mod vi;
 /// An action to perform on an [`Editor`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Action {
-    /// Move cursor to previous character ([Self::Left] in LTR, [Self::Right] in RTL)
-    Previous,
-    /// Move cursor to next character ([Self::Right] in LTR, [Self::Left] in RTL)
-    Next,
-    /// Move cursor left
-    Left,
-    /// Move cursor right
-    Right,
-    /// Move cursor up
-    Up,
-    /// Move cursor down
-    Down,
-    /// Move cursor to start of line
-    Home,
-    /// Move cursor to start of line, skipping whitespace
-    SoftHome,
-    /// Move cursor to end of line
-    End,
-    /// Move cursor to start of paragraph
-    ParagraphStart,
-    /// Move cursor to end of paragraph
-    ParagraphEnd,
-    /// Move cursor up one page
-    PageUp,
-    /// Move cursor down one page
-    PageDown,
-    /// Move cursor up or down by a number of pixels
-    Vertical(i32),
+    /// Move the cursor with some motion
+    Motion(Motion),
     /// Escape, clears selection
     Escape,
     /// Insert character at cursor
@@ -89,20 +63,6 @@ pub enum Action {
     Scroll {
         lines: i32,
     },
-    /// Move cursor to previous word boundary
-    PreviousWord,
-    /// Move cursor to next word boundary
-    NextWord,
-    /// Move cursor to next word boundary to the left
-    LeftWord,
-    /// Move cursor to next word boundary to the right
-    RightWord,
-    /// Move cursor to the start of the document
-    BufferStart,
-    /// Move cursor to the end of the document
-    BufferEnd,
-    /// Move cursor to specific line
-    GotoLine(usize),
 }
 
 /// A unique change to an editor

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -176,11 +176,7 @@ pub trait Edit<'buffer> {
         match self.buffer_ref_mut() {
             BufferRef::Owned(buffer) => f(buffer),
             BufferRef::Borrowed(buffer) => f(buffer),
-            BufferRef::Arc(arc) => match Arc::get_mut(arc) {
-                Some(buffer) => f(buffer),
-                //TODO: use make_mut?
-                None => panic!("BufferRef::Arc cannot be accessed mutibly"),
-            },
+            BufferRef::Arc(buffer) => f(Arc::make_mut(buffer)),
         }
     }
 

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -9,7 +9,7 @@ use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
 
 use crate::{
     Action, AttrsList, BorrowedWithFontSystem, Buffer, Change, Color, Cursor, Edit, Editor,
-    FontSystem, Selection, Shaping, Style, Weight, Wrap,
+    FontSystem, Selection, Shaping, Style, Weight,
 };
 
 pub use syntect::highlighting::Theme as SyntaxTheme;
@@ -283,7 +283,6 @@ impl<'a> Edit for SyntaxEditor<'a> {
 
             // Update line attributes. This operation only resets if the line changes
             line.set_attrs_list(attrs_list);
-            line.set_wrap(Wrap::Word);
 
             // Perform shaping and layout of this line in order to count if we have reached scroll
             match buffer.line_layout(font_system, line_i) {

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -291,8 +291,8 @@ impl<'a> Edit for ViEditor<'a> {
         self.editor.set_tab_width(tab_width);
     }
 
-    fn shape_as_needed(&mut self, font_system: &mut FontSystem) {
-        self.editor.shape_as_needed(font_system);
+    fn shape_as_needed(&mut self, font_system: &mut FontSystem, prune: bool) {
+        self.editor.shape_as_needed(font_system, prune);
     }
 
     fn delete_range(&mut self, start: Cursor, end: Cursor) {
@@ -443,8 +443,8 @@ impl<'a> Edit for ViEditor<'a> {
                                     editor.insert_at(cursor, "\n", None);
                                     editor.insert_at(cursor, data, None);
 
-                                    // Hack to allow immediate up/down
-                                    editor.shape_as_needed(font_system);
+                                    //TODO: Hack to allow immediate up/down
+                                    editor.shape_as_needed(font_system, false);
 
                                     // Move to inserted line, preserving cursor x position
                                     if after {

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -201,6 +201,16 @@ impl<'a> ViEditor<'a> {
         self.editor.foreground_color()
     }
 
+    /// Get the default cursor color
+    pub fn cursor_color(&self) -> Color {
+        self.editor.cursor_color()
+    }
+
+    /// Get the default selection color
+    pub fn selection_color(&self) -> Color {
+        self.editor.selection_color()
+    }
+
     /// Get the current syntect theme
     pub fn theme(&self) -> &SyntaxTheme {
         self.editor.theme()
@@ -246,6 +256,218 @@ impl<'a> ViEditor<'a> {
             undo_2_action(&mut self.editor, action);
             //TODO: clear changed flag when back to last saved state?
             self.changed = true;
+        }
+    }
+
+    #[cfg(feature = "swash")]
+    pub fn draw<F>(&self, font_system: &mut FontSystem, cache: &mut crate::SwashCache, mut f: F)
+    where
+        F: FnMut(i32, i32, u32, u32, Color),
+    {
+        let size = self.buffer().size();
+        f(0, 0, size.0 as u32, size.1 as u32, self.background_color());
+
+        let font_size = self.buffer().metrics().font_size;
+        let line_height = self.buffer().metrics().line_height;
+        let foreground_color = self.foreground_color();
+        let cursor_color = self.cursor_color();
+        let selection_color = self.selection_color();
+
+        for run in self.buffer().layout_runs() {
+            let line_i = run.line_i;
+            let line_y = run.line_y;
+            let line_top = run.line_top;
+
+            let cursor_glyph_opt = |cursor: &Cursor| -> Option<(usize, f32, f32)> {
+                //TODO: better calculation of width
+                let default_width = font_size / 2.0;
+                if cursor.line == line_i {
+                    for (glyph_i, glyph) in run.glyphs.iter().enumerate() {
+                        if cursor.index >= glyph.start && cursor.index < glyph.end {
+                            // Guess x offset based on characters
+                            let mut before = 0;
+                            let mut total = 0;
+
+                            let cluster = &run.text[glyph.start..glyph.end];
+                            for (i, _) in cluster.grapheme_indices(true) {
+                                if glyph.start + i < cursor.index {
+                                    before += 1;
+                                }
+                                total += 1;
+                            }
+
+                            let width = glyph.w / (total as f32);
+                            let offset = (before as f32) * width;
+                            return Some((glyph_i, offset, width));
+                        }
+                    }
+                    match run.glyphs.last() {
+                        Some(glyph) => {
+                            if cursor.index == glyph.end {
+                                return Some((run.glyphs.len(), 0.0, default_width));
+                            }
+                        }
+                        None => {
+                            return Some((0, 0.0, default_width));
+                        }
+                    }
+                }
+                None
+            };
+
+            // Highlight selection (TODO: HIGHLIGHT COLOR!)
+            if let Some((start, end)) = self.selection_bounds() {
+                if line_i >= start.line && line_i <= end.line {
+                    let mut range_opt = None;
+                    for glyph in run.glyphs.iter() {
+                        // Guess x offset based on characters
+                        let cluster = &run.text[glyph.start..glyph.end];
+                        let total = cluster.grapheme_indices(true).count();
+                        let mut c_x = glyph.x;
+                        let c_w = glyph.w / total as f32;
+                        for (i, c) in cluster.grapheme_indices(true) {
+                            let c_start = glyph.start + i;
+                            let c_end = glyph.start + i + c.len();
+                            if (start.line != line_i || c_end > start.index)
+                                && (end.line != line_i || c_start < end.index)
+                            {
+                                range_opt = match range_opt.take() {
+                                    Some((min, max)) => Some((
+                                        cmp::min(min, c_x as i32),
+                                        cmp::max(max, (c_x + c_w) as i32),
+                                    )),
+                                    None => Some((c_x as i32, (c_x + c_w) as i32)),
+                                };
+                            } else if let Some((min, max)) = range_opt.take() {
+                                f(
+                                    min,
+                                    line_top as i32,
+                                    cmp::max(0, max - min) as u32,
+                                    line_height as u32,
+                                    selection_color,
+                                );
+                            }
+                            c_x += c_w;
+                        }
+                    }
+
+                    if run.glyphs.is_empty() && end.line > line_i {
+                        // Highlight all of internal empty lines
+                        range_opt = Some((0, self.buffer().size().0 as i32));
+                    }
+
+                    if let Some((mut min, mut max)) = range_opt.take() {
+                        if end.line > line_i {
+                            // Draw to end of line
+                            if run.rtl {
+                                min = 0;
+                            } else {
+                                max = self.buffer().size().0 as i32;
+                            }
+                        }
+                        f(
+                            min,
+                            line_top as i32,
+                            cmp::max(0, max - min) as u32,
+                            line_height as u32,
+                            selection_color,
+                        );
+                    }
+                }
+            }
+
+            // Draw cursor
+            if let Some((cursor_glyph, cursor_glyph_offset, cursor_glyph_width)) =
+                cursor_glyph_opt(&self.cursor())
+            {
+                let block_cursor = if self.passthrough {
+                    false
+                } else {
+                    match self.parser.mode {
+                        ViMode::Insert | ViMode::Replace => false,
+                        _ => true, /*TODO: determine block cursor in other modes*/
+                    }
+                };
+
+                let (start_x, end_x) = match run.glyphs.get(cursor_glyph) {
+                    Some(glyph) => {
+                        // Start of detected glyph
+                        if glyph.level.is_rtl() {
+                            (
+                                (glyph.x + glyph.w - cursor_glyph_offset) as i32,
+                                (glyph.x + glyph.w - cursor_glyph_offset - cursor_glyph_width)
+                                    as i32,
+                            )
+                        } else {
+                            (
+                                (glyph.x + cursor_glyph_offset) as i32,
+                                (glyph.x + cursor_glyph_offset + cursor_glyph_width) as i32,
+                            )
+                        }
+                    }
+                    None => match run.glyphs.last() {
+                        Some(glyph) => {
+                            // End of last glyph
+                            if glyph.level.is_rtl() {
+                                (glyph.x as i32, (glyph.x - cursor_glyph_width) as i32)
+                            } else {
+                                (
+                                    (glyph.x + glyph.w) as i32,
+                                    (glyph.x + glyph.w + cursor_glyph_width) as i32,
+                                )
+                            }
+                        }
+                        None => {
+                            // Start of empty line
+                            (0, cursor_glyph_width as i32)
+                        }
+                    },
+                };
+
+                if block_cursor {
+                    let left_x = cmp::min(start_x, end_x);
+                    let right_x = cmp::max(start_x, end_x);
+                    f(
+                        left_x,
+                        line_top as i32,
+                        (right_x - left_x) as u32,
+                        line_height as u32,
+                        selection_color,
+                    );
+                } else {
+                    f(
+                        start_x,
+                        line_top as i32,
+                        1,
+                        line_height as u32,
+                        cursor_color,
+                    );
+                }
+            }
+
+            for glyph in run.glyphs.iter() {
+                let physical_glyph = glyph.physical((0., 0.), 1.0);
+
+                let glyph_color = match glyph.color_opt {
+                    Some(some) => some,
+                    None => foreground_color,
+                };
+
+                cache.with_pixels(
+                    font_system,
+                    physical_glyph.cache_key,
+                    glyph_color,
+                    |x, y, color| {
+                        f(
+                            physical_glyph.x + x,
+                            line_y as i32 + physical_glyph.y + y,
+                            1,
+                            1,
+                            color,
+                        );
+                    },
+                );
+            }
         }
     }
 }
@@ -838,214 +1060,6 @@ impl<'a> Edit for ViEditor<'a> {
             editor.action(font_system, action);
         });
     }
-
-    #[cfg(feature = "swash")]
-    fn draw<F>(
-        &self,
-        font_system: &mut FontSystem,
-        cache: &mut crate::SwashCache,
-        color: Color,
-        mut f: F,
-    ) where
-        F: FnMut(i32, i32, u32, u32, Color),
-    {
-        let size = self.buffer().size();
-        f(0, 0, size.0 as u32, size.1 as u32, self.background_color());
-
-        let font_size = self.buffer().metrics().font_size;
-        let line_height = self.buffer().metrics().line_height;
-
-        for run in self.buffer().layout_runs() {
-            let line_i = run.line_i;
-            let line_y = run.line_y;
-            let line_top = run.line_top;
-
-            let cursor_glyph_opt = |cursor: &Cursor| -> Option<(usize, f32, f32)> {
-                //TODO: better calculation of width
-                let default_width = font_size / 2.0;
-                if cursor.line == line_i {
-                    for (glyph_i, glyph) in run.glyphs.iter().enumerate() {
-                        if cursor.index >= glyph.start && cursor.index < glyph.end {
-                            // Guess x offset based on characters
-                            let mut before = 0;
-                            let mut total = 0;
-
-                            let cluster = &run.text[glyph.start..glyph.end];
-                            for (i, _) in cluster.grapheme_indices(true) {
-                                if glyph.start + i < cursor.index {
-                                    before += 1;
-                                }
-                                total += 1;
-                            }
-
-                            let width = glyph.w / (total as f32);
-                            let offset = (before as f32) * width;
-                            return Some((glyph_i, offset, width));
-                        }
-                    }
-                    match run.glyphs.last() {
-                        Some(glyph) => {
-                            if cursor.index == glyph.end {
-                                return Some((run.glyphs.len(), 0.0, default_width));
-                            }
-                        }
-                        None => {
-                            return Some((0, 0.0, default_width));
-                        }
-                    }
-                }
-                None
-            };
-
-            // Highlight selection (TODO: HIGHLIGHT COLOR!)
-            if let Some((start, end)) = self.selection_bounds() {
-                if line_i >= start.line && line_i <= end.line {
-                    let mut range_opt = None;
-                    for glyph in run.glyphs.iter() {
-                        // Guess x offset based on characters
-                        let cluster = &run.text[glyph.start..glyph.end];
-                        let total = cluster.grapheme_indices(true).count();
-                        let mut c_x = glyph.x;
-                        let c_w = glyph.w / total as f32;
-                        for (i, c) in cluster.grapheme_indices(true) {
-                            let c_start = glyph.start + i;
-                            let c_end = glyph.start + i + c.len();
-                            if (start.line != line_i || c_end > start.index)
-                                && (end.line != line_i || c_start < end.index)
-                            {
-                                range_opt = match range_opt.take() {
-                                    Some((min, max)) => Some((
-                                        cmp::min(min, c_x as i32),
-                                        cmp::max(max, (c_x + c_w) as i32),
-                                    )),
-                                    None => Some((c_x as i32, (c_x + c_w) as i32)),
-                                };
-                            } else if let Some((min, max)) = range_opt.take() {
-                                f(
-                                    min,
-                                    line_top as i32,
-                                    cmp::max(0, max - min) as u32,
-                                    line_height as u32,
-                                    Color::rgba(color.r(), color.g(), color.b(), 0x33),
-                                );
-                            }
-                            c_x += c_w;
-                        }
-                    }
-
-                    if run.glyphs.is_empty() && end.line > line_i {
-                        // Highlight all of internal empty lines
-                        range_opt = Some((0, self.buffer().size().0 as i32));
-                    }
-
-                    if let Some((mut min, mut max)) = range_opt.take() {
-                        if end.line > line_i {
-                            // Draw to end of line
-                            if run.rtl {
-                                min = 0;
-                            } else {
-                                max = self.buffer().size().0 as i32;
-                            }
-                        }
-                        f(
-                            min,
-                            line_top as i32,
-                            cmp::max(0, max - min) as u32,
-                            line_height as u32,
-                            Color::rgba(color.r(), color.g(), color.b(), 0x33),
-                        );
-                    }
-                }
-            }
-
-            // Draw cursor
-            if let Some((cursor_glyph, cursor_glyph_offset, cursor_glyph_width)) =
-                cursor_glyph_opt(&self.cursor())
-            {
-                let block_cursor = if self.passthrough {
-                    false
-                } else {
-                    match self.parser.mode {
-                        ViMode::Insert | ViMode::Replace => false,
-                        _ => true, /*TODO: determine block cursor in other modes*/
-                    }
-                };
-
-                let (start_x, end_x) = match run.glyphs.get(cursor_glyph) {
-                    Some(glyph) => {
-                        // Start of detected glyph
-                        if glyph.level.is_rtl() {
-                            (
-                                (glyph.x + glyph.w - cursor_glyph_offset) as i32,
-                                (glyph.x + glyph.w - cursor_glyph_offset - cursor_glyph_width)
-                                    as i32,
-                            )
-                        } else {
-                            (
-                                (glyph.x + cursor_glyph_offset) as i32,
-                                (glyph.x + cursor_glyph_offset + cursor_glyph_width) as i32,
-                            )
-                        }
-                    }
-                    None => match run.glyphs.last() {
-                        Some(glyph) => {
-                            // End of last glyph
-                            if glyph.level.is_rtl() {
-                                (glyph.x as i32, (glyph.x - cursor_glyph_width) as i32)
-                            } else {
-                                (
-                                    (glyph.x + glyph.w) as i32,
-                                    (glyph.x + glyph.w + cursor_glyph_width) as i32,
-                                )
-                            }
-                        }
-                        None => {
-                            // Start of empty line
-                            (0, cursor_glyph_width as i32)
-                        }
-                    },
-                };
-
-                if block_cursor {
-                    let left_x = cmp::min(start_x, end_x);
-                    let right_x = cmp::max(start_x, end_x);
-                    f(
-                        left_x,
-                        line_top as i32,
-                        (right_x - left_x) as u32,
-                        line_height as u32,
-                        Color::rgba(color.r(), color.g(), color.b(), 0x33),
-                    );
-                } else {
-                    f(start_x, line_top as i32, 1, line_height as u32, color);
-                }
-            }
-
-            for glyph in run.glyphs.iter() {
-                let physical_glyph = glyph.physical((0., 0.), 1.0);
-
-                let glyph_color = match glyph.color_opt {
-                    Some(some) => some,
-                    None => color,
-                };
-
-                cache.with_pixels(
-                    font_system,
-                    physical_glyph.cache_key,
-                    glyph_color,
-                    |x, y, color| {
-                        f(
-                            physical_glyph.x + x,
-                            line_y as i32 + physical_glyph.y + y,
-                            1,
-                            1,
-                            color,
-                        );
-                    },
-                );
-            }
-        }
-    }
 }
 
 impl<'a, 'b> BorrowedWithFontSystem<'b, ViEditor<'a>> {
@@ -1057,5 +1071,13 @@ impl<'a, 'b> BorrowedWithFontSystem<'b, ViEditor<'a>> {
         attrs: crate::Attrs,
     ) -> std::io::Result<()> {
         self.inner.load_text(self.font_system, path, attrs)
+    }
+
+    #[cfg(feature = "swash")]
+    pub fn draw<F>(&mut self, cache: &mut crate::SwashCache, f: F)
+    where
+        F: FnMut(i32, i32, u32, u32, Color),
+    {
+        self.inner.draw(self.font_system, cache, f);
     }
 }

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -3,10 +3,11 @@
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use alloc::collections::BTreeSet;
 use fontdb::Family;
 use unicode_script::Script;
 
-use crate::{Font, FontSystem, ShapePlanCache};
+use crate::{Font, FontSystem, ShapePlanCache, FontMatchKey};
 
 use self::platform::*;
 
@@ -31,10 +32,21 @@ use log::debug as missing_warn;
 #[cfg(feature = "warn_on_missing_glyphs")]
 use log::warn as missing_warn;
 
+// Match on lowest weight_offset, then script_non_matches
+// Default font gets None for both `weight_offset` and `script_non_matches`, and thus, it is
+// always the first to be popped from the set.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct MonospaceFallbackInfo {
+    weight_offset: Option<u16>,
+    script_non_matches: Option<usize>,
+    id: fontdb::ID,
+}
+
 pub struct FontFallbackIter<'a> {
     font_system: &'a mut FontSystem,
-    font_ids: &'a [fontdb::ID],
+    font_match_keys: &'a [FontMatchKey],
     default_families: &'a [&'a Family<'a>],
+    monospace_fallbacks: BTreeSet<MonospaceFallbackInfo>,
     default_i: usize,
     scripts: &'a [Script],
     script_i: (usize, usize),
@@ -46,14 +58,15 @@ pub struct FontFallbackIter<'a> {
 impl<'a> FontFallbackIter<'a> {
     pub fn new(
         font_system: &'a mut FontSystem,
-        font_ids: &'a [fontdb::ID],
+        font_match_keys: &'a [FontMatchKey],
         default_families: &'a [&'a Family<'a>],
         scripts: &'a [Script],
     ) -> Self {
         Self {
             font_system,
-            font_ids,
+            font_match_keys,
             default_families,
+            monospace_fallbacks: BTreeSet::new(),
             default_i: 0,
             scripts,
             script_i: (0, 0),
@@ -76,7 +89,7 @@ impl<'a> FontFallbackIter<'a> {
                 "Failed to find preset fallback for {:?} locale '{}', used '{}': '{}'",
                 self.scripts,
                 self.font_system.locale(),
-                self.face_name(self.font_ids[self.other_i - 1]),
+                self.face_name(self.font_match_keys[self.other_i - 1].id),
                 word
             );
         } else if !self.scripts.is_empty() && self.common_i > 0 {
@@ -119,34 +132,71 @@ impl<'a> FontFallbackIter<'a> {
 impl<'a> Iterator for FontFallbackIter<'a> {
     type Item = Arc<Font>;
     fn next(&mut self) -> Option<Self::Item> {
+        if let Some(fallback_info) = self.monospace_fallbacks.pop_first() {
+            if let Some(font) = self.font_system.get_font(fallback_info.id) {
+                return Some(font);
+            }
+        }
+
+        let font_match_keys_iter = |is_mono| self.font_match_keys
+                .iter()
+                .filter(move |m_key| m_key.weight_offset == 0 || is_mono);
+
         while self.default_i < self.default_families.len() {
             self.default_i += 1;
-            let mut monospace_fallback = None;
-            for id in self.font_ids.iter() {
+            let is_mono = self.default_families[self.default_i - 1] == &Family::Monospace;
+
+            for m_key in font_match_keys_iter(is_mono) {
                 let default_family = self
                     .font_system
                     .db()
                     .family_name(self.default_families[self.default_i - 1]);
-                if self.face_contains_family(*id, default_family) {
-                    if let Some(font) = self.font_system.get_font(*id) {
-                        return Some(font);
+                if self.face_contains_family(m_key.id, default_family) {
+                    if let Some(font) = self.font_system.get_font(m_key.id) {
+                        if !is_mono {
+                            return Some(font);
+                        } else if m_key.weight_offset == 0 {
+                            // Default font
+                            let fallback_info = MonospaceFallbackInfo {
+                                weight_offset: None,
+                                script_non_matches: None,
+                                id: m_key.id
+                            };
+                            assert_eq!(self.monospace_fallbacks.insert(fallback_info), true);
+                        }
                     }
                 }
                 // Set a monospace fallback if Monospace family is not found
-                if self.default_families[self.default_i - 1] == &Family::Monospace
-                    && monospace_fallback.is_none()
-                {
-                    if let Some(face_info) = self.font_system.db().face(*id) {
+                if is_mono {
+                    let script_tags = self.scripts.iter()
+                        .filter_map(|script| {
+                            let script_as_lower = script.short_name().to_lowercase();
+                            <[u8; 4]>::try_from(script_as_lower.as_bytes()).ok()
+                        }).collect::<Vec<_>>();
+
+                    if let Some(face_info) = self.font_system.db().face(m_key.id) {
                         // Don't use emoji fonts as Monospace
                         if face_info.monospaced && !face_info.post_script_name.contains("Emoji") {
-                            monospace_fallback = Some(id);
+                            if let Some(font) = self.font_system.get_font(m_key.id) {
+                                let script_non_matches = self.scripts.len() - script_tags.iter()
+                                    .filter(|&&script_tag| {
+                                        font.scripts().iter().any(|&tag_bytes| tag_bytes == script_tag)
+                                    }).count();
+
+                                let fallback_info = MonospaceFallbackInfo {
+                                    weight_offset: Some(m_key.weight_offset),
+                                    script_non_matches: Some(script_non_matches),
+                                    id: m_key.id
+                                };
+                                assert_eq!(self.monospace_fallbacks.insert(fallback_info), true);
+                            }
                         }
                     }
                 }
             }
             // If default family is Monospace fallback to first monospaced font
-            if let Some(id) = monospace_fallback {
-                if let Some(font) = self.font_system.get_font(*id) {
+            if let Some(fallback_info) = self.monospace_fallbacks.pop_first() {
+                if let Some(font) = self.font_system.get_font(fallback_info.id) {
                     return Some(font);
                 }
             }
@@ -159,9 +209,9 @@ impl<'a> Iterator for FontFallbackIter<'a> {
             while self.script_i.1 < script_families.len() {
                 let script_family = script_families[self.script_i.1];
                 self.script_i.1 += 1;
-                for id in self.font_ids.iter() {
-                    if self.face_contains_family(*id, script_family) {
-                        if let Some(font) = self.font_system.get_font(*id) {
+                for m_key in font_match_keys_iter(false) {
+                    if self.face_contains_family(m_key.id, script_family) {
+                        if let Some(font) = self.font_system.get_font(m_key.id) {
                             return Some(font);
                         }
                     }
@@ -182,9 +232,9 @@ impl<'a> Iterator for FontFallbackIter<'a> {
         while self.common_i < common_families.len() {
             let common_family = common_families[self.common_i];
             self.common_i += 1;
-            for id in self.font_ids.iter() {
-                if self.face_contains_family(*id, common_family) {
-                    if let Some(font) = self.font_system.get_font(*id) {
+            for m_key in font_match_keys_iter(false) {
+                if self.face_contains_family(m_key.id, common_family) {
+                    if let Some(font) = self.font_system.get_font(m_key.id) {
                         return Some(font);
                     }
                 }
@@ -195,8 +245,8 @@ impl<'a> Iterator for FontFallbackIter<'a> {
         //TODO: do we need to do this?
         //TODO: do not evaluate fonts more than once!
         let forbidden_families = forbidden_fallback();
-        while self.other_i < self.font_ids.len() {
-            let id = self.font_ids[self.other_i];
+        while self.other_i < self.font_match_keys.len() {
+            let id = self.font_match_keys[self.other_i].id;
             self.other_i += 1;
             if forbidden_families
                 .iter()

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -4,6 +4,8 @@ pub(crate) mod fallback;
 use core::fmt;
 
 use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 use rustybuzz::Face as RustybuzzFace;
 use self_cell::self_cell;

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -78,17 +78,23 @@ impl Font {
         let (monospace_em_width, scripts) = {
             db.with_face_data(id, |font_data, face_index| {
                 let face = ttf_parser::Face::parse(font_data, face_index).ok()?;
-                let monospace_em_width = info.monospaced.then(|| {
-                    let hor_advance = face.glyph_hor_advance(face.glyph_index(' ')?)? as f32;
-                    let upem = face.units_per_em() as f32;
-                    Some(hor_advance/upem)
-                }).flatten();
+                let monospace_em_width = info
+                    .monospaced
+                    .then(|| {
+                        let hor_advance = face.glyph_hor_advance(face.glyph_index(' ')?)? as f32;
+                        let upem = face.units_per_em() as f32;
+                        Some(hor_advance / upem)
+                    })
+                    .flatten();
 
                 if info.monospaced && monospace_em_width.is_none() {
                     None?;
                 }
 
-                let scripts = face.tables().gpos.into_iter()
+                let scripts = face
+                    .tables()
+                    .gpos
+                    .into_iter()
                     .chain(face.tables().gsub)
                     .map(|table| table.scripts)
                     .flatten()

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -167,9 +167,6 @@ impl FontSystem {
         #[cfg(not(target_arch = "wasm32"))]
         let now = std::time::Instant::now();
 
-        #[cfg(target_os = "redox")]
-        db.load_fonts_dir("/ui/fonts");
-
         db.load_system_fonts();
 
         for source in fonts {

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -120,7 +120,10 @@ impl FontSystem {
                 match Font::new(&self.db, id) {
                     Some(font) => Some(Arc::new(font)),
                     None => {
-                        log::warn!("failed to load font '{}'", self.db.face(id)?.post_script_name);
+                        log::warn!(
+                            "failed to load font '{}'",
+                            self.db.face(id)?.post_script_name
+                        );
                         None
                     }
                 }
@@ -140,7 +143,10 @@ impl FontSystem {
                     .db
                     .faces()
                     .filter(|face| attrs.matches(face))
-                    .map(|face| FontMatchKey{ weight_offset: attrs.weight.0 - face.weight.0, id: face.id })
+                    .map(|face| FontMatchKey {
+                        weight_offset: attrs.weight.0 - face.weight.0,
+                        id: face.id,
+                    })
                     .collect::<Vec<_>>();
 
                 // Sort so we get the keys with weight_offset=0 first

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -177,7 +177,7 @@ impl FontSystem {
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        log::info!(
+        log::debug!(
             "Parsed {} font faces in {}ms.",
             db.len(),
             now.elapsed().as_millis()

--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -1,5 +1,15 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+bitflags::bitflags! {
+    /// Flags that change rendering
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[repr(transparent)]
+    pub struct CacheKeyFlags: u32 {
+        /// Skew by 14 degrees to synthesize italic
+        const FAKE_ITALIC = 1;
+    }
+}
+
 /// Key for building a glyph cache
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CacheKey {
@@ -13,6 +23,8 @@ pub struct CacheKey {
     pub x_bin: SubpixelBin,
     /// Binning of fractional Y offset
     pub y_bin: SubpixelBin,
+    /// [`CacheKeyFlags`]
+    pub flags: CacheKeyFlags,
 }
 
 impl CacheKey {
@@ -21,6 +33,7 @@ impl CacheKey {
         glyph_id: u16,
         font_size: f32,
         pos: (f32, f32),
+        flags: CacheKeyFlags,
     ) -> (Self, i32, i32) {
         let (x, x_bin) = SubpixelBin::new(pos.0);
         let (y, y_bin) = SubpixelBin::new(pos.1);
@@ -31,6 +44,7 @@ impl CacheKey {
                 font_size_bits: font_size.to_bits(),
                 x_bin,
                 y_bin,
+                flags,
             },
             x,
             y,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -5,7 +5,7 @@ use core::fmt::Display;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::{CacheKey, Color};
+use crate::{CacheKey, CacheKeyFlags, Color};
 
 /// A laid out glyph
 #[derive(Clone, Debug)]
@@ -50,6 +50,8 @@ pub struct LayoutGlyph {
     pub color_opt: Option<Color>,
     /// Metadata from `Attrs`
     pub metadata: usize,
+    /// [`CacheKeyFlags`]
+    pub cache_key_flags: CacheKeyFlags,
 }
 
 #[derive(Clone, Debug)]
@@ -75,6 +77,7 @@ impl LayoutGlyph {
                 (self.x + x_offset) * scale + offset.0,
                 libm::truncf((self.y - y_offset) * scale + offset.1), // Hinting in Y axis
             ),
+            self.cache_key_flags,
         );
 
         PhysicalGlyph { cache_key, x, y }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! buffer.set_text("Hello, Rust! 🦀\n", attrs, Shaping::Advanced);
 //!
 //! // Perform shaping as desired
-//! buffer.shape_until_scroll();
+//! buffer.shape_until_scroll(true);
 //!
 //! // Inspect the output runs
 //! for run in buffer.layout_runs() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,9 @@ mod buffer_line;
 pub use self::glyph_cache::*;
 mod glyph_cache;
 
+pub use self::cursor::*;
+mod cursor;
+
 pub use self::edit::*;
 mod edit;
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -13,7 +13,8 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::fallback::FontFallbackIter;
 use crate::{
-    Align, AttrsList, Color, Font, FontSystem, LayoutGlyph, LayoutLine, ShapePlanCache, Wrap,
+    Align, AttrsList, CacheKeyFlags, Color, Font, FontSystem, LayoutGlyph, LayoutLine,
+    ShapePlanCache, Wrap,
 };
 
 /// The shaping strategy of some text.
@@ -148,6 +149,7 @@ fn shape_fallback(
             //TODO: color should not be related to shaping
             color_opt: attrs.color_opt,
             metadata: attrs.metadata,
+            cache_key_flags: attrs.cache_key_flags,
         });
     }
 
@@ -373,6 +375,7 @@ fn shape_skip(
                     glyph_id,
                     color_opt: attrs.color_opt,
                     metadata: attrs.metadata,
+                    cache_key_flags: attrs.cache_key_flags,
                 }
             }),
     );
@@ -393,6 +396,7 @@ pub struct ShapeGlyph {
     pub glyph_id: u16,
     pub color_opt: Option<Color>,
     pub metadata: usize,
+    pub cache_key_flags: CacheKeyFlags,
 }
 
 impl ShapeGlyph {
@@ -418,6 +422,7 @@ impl ShapeGlyph {
             y_offset: self.y_offset,
             color_opt: self.color_opt,
             metadata: self.metadata,
+            cache_key_flags: self.cache_key_flags,
         }
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1247,12 +1247,18 @@ impl ShapeLine {
                         let match_mono_em_width = match_mono_width.map(|w| w / font_size);
 
                         for glyph in included_glyphs {
-                            let glyph_font_size = match(match_mono_em_width, glyph.font_monospace_em_width) {
-                                (Some(match_em_width), Some(glyph_em_width)) if glyph_em_width != match_em_width => {
-                                    let glyph_font_size = font_size * (match_em_width / glyph_em_width);
+                            let glyph_font_size = match (
+                                match_mono_em_width,
+                                glyph.font_monospace_em_width,
+                            ) {
+                                (Some(match_em_width), Some(glyph_em_width))
+                                    if glyph_em_width != match_em_width =>
+                                {
+                                    let glyph_font_size =
+                                        font_size * (match_em_width / glyph_em_width);
                                     log::trace!("Adjusted glyph font size ({font_size} => {glyph_font_size})");
                                     glyph_font_size
-                                },
+                                }
                                 _ => font_size,
                             };
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -379,7 +379,7 @@ fn shape_skip(
 }
 
 /// A shaped glyph
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ShapeGlyph {
     pub start: usize,
     pub end: usize,
@@ -423,7 +423,7 @@ impl ShapeGlyph {
 }
 
 /// A shaped word (for word wrapping)
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ShapeWord {
     pub blank: bool,
     pub glyphs: Vec<ShapeGlyph>,
@@ -527,7 +527,7 @@ impl ShapeWord {
 }
 
 /// A shaped span (for bidirectional processing)
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ShapeSpan {
     pub level: unicode_bidi::Level,
     pub words: Vec<ShapeWord>,
@@ -638,7 +638,7 @@ impl ShapeSpan {
 }
 
 /// A shaped line (or paragraph)
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ShapeLine {
     pub rtl: bool,
     pub spans: Vec<ShapeSpan>,

--- a/src/swash.rs
+++ b/src/swash.rs
@@ -7,10 +7,10 @@ use swash::scale::{image::Content, ScaleContext};
 use swash::scale::{Render, Source, StrikeWith};
 use swash::zeno::{Format, Vector};
 
-use crate::{CacheKey, Color, FontSystem, HashMap};
+use crate::{CacheKey, CacheKeyFlags, Color, FontSystem, HashMap};
 
 pub use swash::scale::image::{Content as SwashContent, Image as SwashImage};
-pub use swash::zeno::{Command, Placement};
+pub use swash::zeno::{Angle, Command, Placement, Transform};
 
 fn swash_image(
     font_system: &mut FontSystem,
@@ -49,6 +49,14 @@ fn swash_image(
     .format(Format::Alpha)
     // Apply the fractional offset
     .offset(offset)
+    .transform(if cache_key.flags.contains(CacheKeyFlags::FAKE_ITALIC) {
+        Some(Transform::skew(
+            Angle::from_degrees(14.0),
+            Angle::from_degrees(0.0),
+        ))
+    } else {
+        None
+    })
     // Render the image
     .render(&mut scaler, cache_key.glyph_id)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -93,7 +93,7 @@ impl DrawTestCfg {
             (self.canvas_height - margins * 2) as f32,
         );
         buffer.set_text(&self.text, self.font.as_attrs(), Shaping::Advanced);
-        buffer.shape_until_scroll();
+        buffer.shape_until_scroll(true);
 
         // Black
         let text_color = Color::rgb(0x00, 0x00, 0x00);

--- a/tests/wrap_stability.rs
+++ b/tests/wrap_stability.rs
@@ -23,11 +23,11 @@ fn stable_wrap() {
     let mut check_wrap = |text: &_, wrap, start_width| {
         let line = ShapeLine::new(&mut font_system, text, &attrs, Shaping::Advanced);
 
-        let layout_unbounded = line.layout(font_size, start_width, wrap, Some(Align::Left));
+        let layout_unbounded = line.layout(font_size, start_width, wrap, Some(Align::Left), None);
         let max_width = layout_unbounded.iter().map(|l| l.w).fold(0.0, f32::max);
         let new_limit = f32::min(start_width, max_width);
 
-        let layout_bounded = line.layout(font_size, new_limit, wrap, Some(Align::Left));
+        let layout_bounded = line.layout(font_size, new_limit, wrap, Some(Align::Left), None);
         let bounded_max_width = layout_bounded.iter().map(|l| l.w).fold(0.0, f32::max);
 
         // For debugging:


### PR DESCRIPTION
Includes various performance improvements, refactor of cursor motion so it can be done outside of Editor, refactoring of scroll so that previous lines do not have to be shaped, and the ability to prune caches to reduce memory usage.

The most important change is to allow shaping parts of a buffer, by changing scroll to include both an index in Buffer::lines and the layout line. This lets only the part currently within the scrolled view of the buffer to be shaped and laid out. This greatly improves performance when scrolling as it does not have to shape and lay out lines that were never shown.

The shaping functions for Buffer and Editor now take a `prune` parameter, which when set to true, will drop the shaping and layout information of all lines outside of the scrolled view. This greatly decreases memory usage at the cost of reshaping when scrolling.