### PR TITLE
Multiply by a glyph-to-default rounded factor when resizing fonts

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1254,8 +1254,10 @@ impl ShapeLine {
                                 (Some(match_em_width), Some(glyph_em_width))
                                     if glyph_em_width != match_em_width =>
                                 {
-                                    let glyph_font_size =
-                                        font_size * (match_em_width / glyph_em_width);
+                                    let glyph_to_match_factor = glyph_em_width / match_em_width;
+                                    let glyph_font_size = glyph_to_match_factor.round().max(1.0)
+                                        / glyph_to_match_factor
+                                        * font_size;
                                     log::trace!("Adjusted glyph font size ({font_size} => {glyph_font_size})");
                                     glyph_font_size
                                 }


### PR DESCRIPTION
 When matching to a default monospace width, big fonts like those
 containing symbols and emojis got too small from font resizing.

 Adding a glyph-to-default rounded factor to the calculation should fix
 that issue without losing monospatiality.

 Fixes pop-os/cosmic-term#69.