### PR TITLE
Add a size limit to `font_matches_cache` and empty it when it's reached

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -191,6 +191,26 @@ impl<'a> Attrs<'a> {
     }
 }
 
+/// Font-specific part of [`Attrs`] to be used for matching
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct FontMatchAttrs {
+    family: FamilyOwned,
+    stretch: Stretch,
+    style: Style,
+    weight: Weight,
+}
+
+impl<'a> From<Attrs<'a>> for FontMatchAttrs {
+    fn from(attrs: Attrs<'a>) -> Self {
+        Self {
+            family: FamilyOwned::new(attrs.family),
+            stretch: attrs.stretch,
+            style: attrs.style,
+            weight: attrs.weight,
+        }
+    }
+}
+
 /// An owned version of [`Attrs`]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct AttrsOwned {

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -1,4 +1,4 @@
-use crate::{Attrs, AttrsOwned, Font, HashMap, ShapePlanCache};
+use crate::{Attrs, Font, FontMatchAttrs, HashMap, ShapePlanCache};
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -27,7 +27,7 @@ pub struct FontSystem {
     font_cache: HashMap<fontdb::ID, Option<Arc<Font>>>,
 
     /// Cache for font matches.
-    font_matches_cache: HashMap<AttrsOwned, Arc<Vec<FontMatchKey>>>,
+    font_matches_cache: HashMap<FontMatchAttrs, Arc<Vec<FontMatchKey>>>,
 
     /// Cache for rustybuzz shape plans.
     shape_plan_cache: ShapePlanCache,
@@ -141,7 +141,7 @@ impl FontSystem {
 
         self.font_matches_cache
             //TODO: do not create AttrsOwned unless entry does not already exist
-            .entry(AttrsOwned::new(attrs))
+            .entry(attrs.into())
             .or_insert_with(|| {
                 #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
                 let now = std::time::Instant::now();

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -43,6 +43,7 @@ impl fmt::Debug for FontSystem {
 }
 
 impl FontSystem {
+    const FONT_MATCHES_CACHE_SIZE_LIMIT: usize = 256;
     /// Create a new [`FontSystem`], that allows access to any installed system fonts
     ///
     /// # Timing
@@ -132,6 +133,12 @@ impl FontSystem {
     }
 
     pub fn get_font_matches(&mut self, attrs: Attrs<'_>) -> Arc<Vec<FontMatchKey>> {
+        // Clear the cache first if it reached the size limit
+        if self.font_matches_cache.len() >= Self::FONT_MATCHES_CACHE_SIZE_LIMIT {
+            log::trace!("clear font mache cache");
+            self.font_matches_cache.clear();
+        }
+
         self.font_matches_cache
             //TODO: do not create AttrsOwned unless entry does not already exist
             .entry(AttrsOwned::new(attrs))


### PR DESCRIPTION
 In `FontSystem`, `font_matches_cache` is an ever growing cache.

 It can also be a fast growing one in stress tests like running this
 in `cosmic-term`:

     mpv -speed 3 -vo tct <some_video>

 So this commit adds a size limit to that cache, and simply empties
 it when that limit is reached, which shouldn't be a common occurrence
 in normal usage.