### PR TITLE
Use weight absolute difference in monospace fallback matching

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -176,10 +176,7 @@ impl<'a> Attrs<'a> {
     pub fn matches(&self, face: &fontdb::FaceInfo) -> bool {
         //TODO: smarter way of including emoji
         face.post_script_name.contains("Emoji")
-            || (face.style == self.style
-                // Relax exact weight matching for the Monospace fallback use-case
-                && face.weight <= self.weight
-                && face.stretch == self.stretch)
+            || (face.style == self.style && face.stretch == self.stretch)
     }
 
     /// Check if this set of attributes can be shaped with another

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -11,7 +11,8 @@ pub use rustybuzz;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FontMatchKey {
-    pub(crate) weight_offset: Option<u16>,
+    pub(crate) font_weight_diff: u16,
+    pub(crate) font_weight: u16,
     pub(crate) id: fontdb::ID,
 }
 
@@ -151,7 +152,8 @@ impl FontSystem {
                     .faces()
                     .filter(|face| attrs.matches(face))
                     .map(|face| FontMatchKey {
-                        weight_offset: attrs.weight.0.checked_sub(face.weight.0),
+                        font_weight_diff: attrs.weight.0.abs_diff(face.weight.0),
+                        font_weight: face.weight.0,
                         id: face.id,
                     })
                     .collect::<Vec<_>>();


### PR DESCRIPTION
 When matching on weights smaller than normal, "equal or smaller"
 weight restriction may cause monospace fallback to fail, depending
 on font support at such weights for the text to be shaped.

 So remove that restriction, and calculate weight differences instead
 of offsets.

 In case of no exact weight match, and with all other factors being
 equal, smaller weights will be picked before bigger ones. So, this
 should generally not cause any behavioral changes when matching on
 normal weight or bigger.

 Should fix pop-os/cosmic-term#104.