### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rangemap = "1.4.0"
 rustc-hash = { version = "1.1.0", default-features = false }
 rustybuzz = { version = "0.12.0", default-features = false, features = ["libm"] }
 self_cell = "1.0.1"
+serde = { version = "1.0.196", features = ["derive"], optional = true, default-features = false }
 swash = { version = "0.1.12", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
@@ -48,6 +49,7 @@ vi = ["modit", "syntect", "cosmic_undo_2"]
 wasm-web = ["sys-locale?/js"]
 warn_on_missing_glyphs = []
 fontconfig = ["fontdb/fontconfig", "std"]
+serde = ["dep:serde", "fontdb/serde", "rangemap/serde1", "bitflags/serde"]
 
 [[bench]]
 name = "layout"

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -7,6 +7,8 @@ use alloc::{
 };
 use core::ops::Range;
 use rangemap::RangeMap;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::CacheKeyFlags;
 
@@ -14,6 +16,7 @@ pub use fontdb::{Family, Stretch, Style, Weight};
 
 /// Text color
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Color(pub u32);
 
 impl Color {
@@ -68,6 +71,7 @@ impl Color {
 
 /// An owned version of [`Family`]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum FamilyOwned {
     Name(String),
     Serif,
@@ -103,9 +107,11 @@ impl FamilyOwned {
 
 /// Text attributes
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Attrs<'a> {
     //TODO: should this be an option?
     pub color_opt: Option<Color>,
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub family: Family<'a>,
     pub stretch: Stretch,
     pub style: Style,
@@ -190,6 +196,7 @@ impl<'a> Attrs<'a> {
 
 /// Font-specific part of [`Attrs`] to be used for matching
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FontMatchAttrs {
     family: FamilyOwned,
     stretch: Stretch,
@@ -210,6 +217,7 @@ impl<'a> From<Attrs<'a>> for FontMatchAttrs {
 
 /// An owned version of [`Attrs`]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AttrsOwned {
     //TODO: should this be an option?
     pub color_opt: Option<Color>,
@@ -250,6 +258,7 @@ impl AttrsOwned {
 /// List of text attributes to apply to a line
 //TODO: have this clean up the spans when changes are made
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AttrsList {
     defaults: AttrsOwned,
     spans: RangeMap<usize, AttrsOwned>,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,6 +5,9 @@ use alloc::{string::String, vec::Vec};
 use core::{cmp, fmt};
 use unicode_segmentation::UnicodeSegmentation;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     Affinity, Attrs, AttrsList, BidiParagraphs, BorrowedWithFontSystem, BufferLine, Color, Cursor,
     FontSystem, LayoutCursor, LayoutGlyph, LayoutLine, Motion, Scroll, ShapeBuffer, ShapeLine,
@@ -191,6 +194,7 @@ impl<'b> ExactSizeIterator for LayoutRunIter<'b> {}
 
 /// Metrics of text
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Metrics {
     /// Font size in pixels
     pub font_size: f32,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Current cursor location
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Cursor {
     /// Index of [`BufferLine`] in [`Buffer::lines`]
     pub line: usize,
@@ -28,6 +32,7 @@ impl Cursor {
 
 /// Whether to associate cursors placed at a boundary between runs with the run before or after it.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Affinity {
     #[default]
     Before,

--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 bitflags::bitflags! {
     /// Flags that change rendering
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     #[repr(transparent)]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
     pub struct CacheKeyFlags: u32 {
         /// Skew by 14 degrees to synthesize italic
         const FAKE_ITALIC = 1;
@@ -54,6 +57,7 @@ impl CacheKey {
 
 /// Binning of subpixel position for cache optimization
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum SubpixelBin {
     Zero,
     One,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -7,6 +7,9 @@ use alloc::vec::Vec;
 
 use crate::{CacheKey, CacheKeyFlags, Color};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A laid out glyph
 #[derive(Clone, Debug)]
 pub struct LayoutGlyph {
@@ -99,6 +102,7 @@ pub struct LayoutLine {
 
 /// Wrapping mode
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Wrap {
     /// No wrapping
     None,
@@ -123,6 +127,7 @@ impl Display for Wrap {
 
 /// Align or justify
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Align {
     Left,
     Right,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -17,8 +17,12 @@ use crate::{
     ShapePlanCache, Wrap,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// The shaping strategy of some text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Shaping {
     /// Basic shaping with no font fallback.
     ///


### PR DESCRIPTION
This PR is actually a group of 3 PRs

-
-
-

Right now, I'm making a slideshow program which uses `cosmic-text` for shaping and layout. I'd love to be able to serialize my slideshows into a packed serde format, and in order to do that, I need the types in the libraries in these 3 PRs to implement the serde traits. 