### PR TITLE
Fix `no_std` build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ self_cell = "1.0.1"
 swash = { version = "0.1.12", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
-ttf-parser = "0.20.0"
+ttf-parser = { version = "0.20.0", default-features = false }
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.1"
@@ -44,6 +44,7 @@ std = [
     "fontdb/std",
     "rustybuzz/std",
     "sys-locale",
+    "ttf-parser/std",
     "unicode-bidi/std",
 ]
 vi = ["modit", "syntect", "cosmic_undo_2"]

--- a/ci.sh
+++ b/ci.sh
@@ -13,8 +13,12 @@ cargo fmt --check
 echo Build with default features
 build
 
+echo Install target for no_std build
+# This is necessary because Rust otherwise may silently use std regardless.
+rustup target add thumbv8m.main-none-eabihf
+
 echo Build with only no_std feature
-build --no-default-features --features no_std
+build --no-default-features --features no_std --target thumbv8m.main-none-eabihf
 
 echo Build with only std feature
 build --no-default-features --features std

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -2,8 +2,6 @@
 
 use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use fontdb::Family;
 use unicode_script::Script;
 

--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -63,8 +63,9 @@ pub enum SubpixelBin {
 
 impl SubpixelBin {
     pub fn new(pos: f32) -> (i32, Self) {
-        let (fract, truncf) = libm::modff(pos);
-        let trunc = truncf as i32;
+        let trunc = pos as i32;
+        let fract = pos - trunc as f32;
+
         if pos.is_sign_negative() {
             if fract > -0.125 {
                 (trunc, Self::Zero)

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -5,7 +5,7 @@ use core::fmt::Display;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use crate::{CacheKey, CacheKeyFlags, Color};
+use crate::{math, CacheKey, CacheKeyFlags, Color};
 
 /// A laid out glyph
 #[derive(Clone, Debug)]
@@ -75,7 +75,7 @@ impl LayoutGlyph {
             self.font_size * scale,
             (
                 (self.x + x_offset) * scale + offset.0,
-                libm::truncf((self.y - y_offset) * scale + offset.1), // Hinting in Y axis
+                math::truncf((self.y - y_offset) * scale + offset.1), // Hinting in Y axis
             ),
             self.cache_key_flags,
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@ pub use self::swash::*;
 #[cfg(feature = "swash")]
 mod swash;
 
+mod math;
+
 type BuildHasher = core::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 
 #[cfg(feature = "std")]

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,14 @@
+#[cfg(not(feature = "std"))]
+pub use libm::{roundf, truncf};
+
+#[cfg(feature = "std")]
+#[inline]
+pub fn roundf(x: f32) -> f32 {
+    x.round()
+}
+
+#[cfg(feature = "std")]
+#[inline]
+pub fn truncf(x: f32) -> f32 {
+    x.trunc()
+}

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -13,7 +13,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::fallback::FontFallbackIter;
 use crate::{
-    Align, AttrsList, CacheKeyFlags, Color, Font, FontSystem, LayoutGlyph, LayoutLine,
+    math, Align, AttrsList, CacheKeyFlags, Color, Font, FontSystem, LayoutGlyph, LayoutLine,
     ShapePlanCache, Wrap,
 };
 
@@ -1394,7 +1394,8 @@ impl ShapeLine {
                                     if glyph_em_width != match_em_width =>
                                 {
                                     let glyph_to_match_factor = glyph_em_width / match_em_width;
-                                    let glyph_font_size = glyph_to_match_factor.round().max(1.0)
+                                    let glyph_font_size = math::roundf(glyph_to_match_factor)
+                                        .max(1.0)
                                         / glyph_to_match_factor
                                         * font_size;
                                     log::trace!("Adjusted glyph font size ({font_size} => {glyph_font_size})");


### PR DESCRIPTION
This fixes the `no_std` build and also makes sure it's tested properly in the CI workflow.

Resolves #197 