### PR TITLE
Multiple font sizes

### DIFF
--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, BidiParagraphs, BorrowedWithFontSystem, Buffer, Color, Edit, Editor, FontSystem,
-    Metrics, Motion, SwashCache,
+    Action, Attrs, BidiParagraphs, BorrowedWithFontSystem, Buffer, Color, Edit, Editor, FontSystem,
+    LineHeight, Motion, SwashCache,
 };
 use orbclient::{EventOption, Renderer, Window, WindowFlag};
 use std::{env, fs, process, time::Instant};
@@ -60,16 +60,16 @@ fn main() {
     .unwrap();
 
     let font_sizes = [
-        Metrics::new(10.0, 14.0).scale(display_scale), // Caption
-        Metrics::new(14.0, 20.0).scale(display_scale), // Body
-        Metrics::new(20.0, 28.0).scale(display_scale), // Title 4
-        Metrics::new(24.0, 32.0).scale(display_scale), // Title 3
-        Metrics::new(28.0, 36.0).scale(display_scale), // Title 2
-        Metrics::new(32.0, 44.0).scale(display_scale), // Title 1
+        10.0, // Metrics::new(10.0, 14.0).scale(display_scale), // Caption
+        14.0, // Metrics::new(14.0, 20.0).scale(display_scale), // Body
+        20.0, // Metrics::new(20.0, 28.0).scale(display_scale), // Title 4
+        24.0, // Metrics::new(24.0, 32.0).scale(display_scale), // Title 3
+        28.0, // Metrics::new(28.0, 36.0).scale(display_scale), // Title 2
+        32.0, // Metrics::new(32.0, 44.0).scale(display_scale), // Title 1
     ];
     let font_size_default = 1; // Body
 
-    let mut buffer = Buffer::new(&mut font_system, font_sizes[font_size_default]);
+    let mut buffer = Buffer::new(&mut font_system);
     buffer
         .borrow_with(&mut font_system)
         .set_size(window.width() as f32, window.height() as f32);
@@ -89,6 +89,11 @@ fn main() {
         let default_text = include_str!("../../../sample/proportional.txt");
         default_text.to_string()
     };
+
+    let attrs = Attrs::new()
+        .size(font_sizes[font_size_default])
+        .line_height(LineHeight::Proportional(1.2))
+        .scale(display_scale);
 
     let test_start = Instant::now();
 

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use cosmic_text::{
-    Action, Attrs, Buffer, Edit, Family, FontSystem, Metrics, Motion, SwashCache, SyntaxEditor,
+    Action, Attrs, Buffer, Edit, Family, FontSystem, LineHeight, Motion, SwashCache, SyntaxEditor,
     SyntaxSystem,
 };
 use std::{env, num::NonZeroU32, rc::Rc, slice};
@@ -31,28 +31,28 @@ fn main() {
 
     let scrollbar_width = 12.0;
     let font_sizes = [
-        Metrics::new(10.0, 14.0), // Caption
-        Metrics::new(14.0, 20.0), // Body
-        Metrics::new(20.0, 28.0), // Title 4
-        Metrics::new(24.0, 32.0), // Title 3
-        Metrics::new(28.0, 36.0), // Title 2
-        Metrics::new(32.0, 44.0), // Title 1
+        10.0, // Metrics::new(10.0, 14.0).scale(display_scale), // Caption
+        14.0, // Metrics::new(14.0, 20.0).scale(display_scale), // Body
+        20.0, // Metrics::new(20.0, 28.0).scale(display_scale), // Title 4
+        24.0, // Metrics::new(24.0, 32.0).scale(display_scale), // Title 3
+        28.0, // Metrics::new(28.0, 36.0).scale(display_scale), // Title 2
+        32.0, // Metrics::new(32.0, 44.0).scale(display_scale), // Title 1
     ];
     let font_size_default = 1; // Body
     let mut font_size_i = font_size_default;
 
     let mut editor = SyntaxEditor::new(
-        Buffer::new(
-            &mut font_system,
-            font_sizes[font_size_i].scale(display_scale),
-        ),
+        Buffer::new(&mut font_system),
         &syntax_system,
         "base16-eighties.dark",
     )
     .unwrap();
     let mut editor = editor.borrow_with(&mut font_system);
 
-    let attrs = Attrs::new().family(Family::Monospace);
+    let attrs = Attrs::new()
+        .size(font_sizes[font_size_i] * display_scale)
+        .line_height(LineHeight::Proportional(1.2))
+        .family(Family::Monospace);
 
     match editor.load_text(&path, attrs) {
         Ok(()) => (),
@@ -78,9 +78,9 @@ fn main() {
                             log::info!("Updated scale factor for {window_id:?}");
 
                             display_scale = scale_factor as f32;
-                            editor.with_buffer_mut(|buffer| {
-                                buffer.set_metrics(font_sizes[font_size_i].scale(display_scale))
-                            });
+                            // editor.with_buffer_mut(|buffer| {
+                            //     buffer.set_metrics(font_sizes[font_size_i].scale(display_scale))
+                            // });
 
                             window.request_redraw();
                         }
@@ -219,33 +219,33 @@ fn main() {
                                             match &*text {
                                                 "0" => {
                                                     font_size_i = font_size_default;
-                                                    editor.with_buffer_mut(|buffer| {
-                                                        buffer.set_metrics(
-                                                            font_sizes[font_size_i]
-                                                                .scale(display_scale),
-                                                        )
-                                                    });
+                                                    // editor.with_buffer_mut(|buffer| {
+                                                    //     buffer.set_metrics(
+                                                    //         font_sizes[font_size_i]
+                                                    //             .scale(display_scale),
+                                                    //     )
+                                                    // });
                                                 }
                                                 "-" => {
                                                     if font_size_i > 0 {
                                                         font_size_i -= 1;
-                                                        editor.with_buffer_mut(|buffer| {
-                                                            buffer.set_metrics(
-                                                                font_sizes[font_size_i]
-                                                                    .scale(display_scale),
-                                                            )
-                                                        });
+                                                        // editor.with_buffer_mut(|buffer| {
+                                                        //     buffer.set_metrics(
+                                                        //         font_sizes[font_size_i]
+                                                        //             .scale(display_scale),
+                                                        //     )
+                                                        // });
                                                     }
                                                 }
                                                 "=" => {
                                                     if font_size_i + 1 < font_sizes.len() {
                                                         font_size_i += 1;
-                                                        editor.with_buffer_mut(|buffer| {
-                                                            buffer.set_metrics(
-                                                                font_sizes[font_size_i]
-                                                                    .scale(display_scale),
-                                                            )
-                                                        });
+                                                        // editor.with_buffer_mut(|buffer| {
+                                                        //     buffer.set_metrics(
+                                                        //         font_sizes[font_size_i]
+                                                        //             .scale(display_scale),
+                                                        //     )
+                                                        // });
                                                     }
                                                 }
                                                 _ => {}

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -78,13 +78,55 @@ fn set_buffer_text<'a>(buffer: &mut BorrowedWithFontSystem<'a, Buffer>, scale_fa
         ("B", attrs.color(Color::rgb(0x00, 0x00, 0xFF))),
         ("O", attrs.color(Color::rgb(0x4B, 0x00, 0x82))),
         ("W ", attrs.color(Color::rgb(0x94, 0x00, 0xD3))),
-        ("Red ", attrs.color(Color::rgb(0xFF, 0x00, 0x00))),
-        ("Orange ", attrs.color(Color::rgb(0xFF, 0x7F, 0x00))),
-        ("Yellow ", attrs.color(Color::rgb(0xFF, 0xFF, 0x00))),
-        ("Green ", attrs.color(Color::rgb(0x00, 0xFF, 0x00))),
-        ("Blue ", attrs.color(Color::rgb(0x00, 0x00, 0xFF))),
-        ("Indigo ", attrs.color(Color::rgb(0x4B, 0x00, 0x82))),
-        ("Violet ", attrs.color(Color::rgb(0x94, 0x00, 0xD3))),
+        (
+            "Red ",
+            attrs
+                .color(Color::rgb(0xFF, 0x00, 0x00))
+                .size(attrs.font_size * 1.9)
+                .line_height(LineHeight::Proportional(0.9)),
+        ),
+        (
+            "Orange ",
+            attrs
+                .color(Color::rgb(0xFF, 0x7F, 0x00))
+                .size(attrs.font_size * 1.6)
+                .line_height(LineHeight::Proportional(1.0)),
+        ),
+        (
+            "Yellow ",
+            attrs
+                .color(Color::rgb(0xFF, 0xFF, 0x00))
+                .size(attrs.font_size * 1.3)
+                .line_height(LineHeight::Proportional(1.1)),
+        ),
+        (
+            "Green ",
+            attrs
+                .color(Color::rgb(0x00, 0xFF, 0x00))
+                .size(attrs.font_size * 1.0)
+                .line_height(LineHeight::Proportional(1.2)),
+        ),
+        (
+            "Blue ",
+            attrs
+                .color(Color::rgb(0x00, 0x00, 0xFF))
+                .size(attrs.font_size * 0.8)
+                .line_height(LineHeight::Proportional(1.3)),
+        ),
+        (
+            "Indigo ",
+            attrs
+                .color(Color::rgb(0x4B, 0x00, 0x82))
+                .size(attrs.font_size * 0.6)
+                .line_height(LineHeight::Proportional(1.4)),
+        ),
+        (
+            "Violet ",
+            attrs
+                .color(Color::rgb(0x94, 0x00, 0xD3))
+                .size(attrs.font_size * 0.4)
+                .line_height(LineHeight::Proportional(1.5)),
+        ),
         ("U", attrs.color(Color::rgb(0x94, 0x00, 0xD3))),
         ("N", attrs.color(Color::rgb(0x4B, 0x00, 0x82))),
         ("I", attrs.color(Color::rgb(0x00, 0x00, 0xFF))),

--- a/examples/terminal/src/main.rs
+++ b/examples/terminal/src/main.rs
@@ -4,8 +4,12 @@
 //! or `cargo run --package terminal -- "my own text"`
 
 use colored::Colorize;
-use cosmic_text::{Attrs, Buffer, Color, FontSystem, Metrics, Shaping, SwashCache};
+use cosmic_text::{Attrs, Buffer, Color, FontSystem, LineHeight, Shaping, SwashCache};
 use std::fmt::Write;
+
+// Text metrics indicate the font size and line height of a buffer
+const FONT_SIZE: f32 = 14.0;
+const LINE_HEIGHT: f32 = FONT_SIZE * 1.2;
 
 fn main() {
     // A FontSystem provides access to detected system fonts, create one per application
@@ -14,13 +18,8 @@ fn main() {
     // A SwashCache stores rasterized glyphs, create one per application
     let mut swash_cache = SwashCache::new();
 
-    // Text metrics indicate the font size and line height of a buffer
-    const FONT_SIZE: f32 = 14.0;
-    const LINE_HEIGHT: f32 = FONT_SIZE * 1.2;
-    let metrics = Metrics::new(FONT_SIZE, LINE_HEIGHT);
-
     // A Buffer provides shaping and layout for a UTF-8 string, create one per text widget
-    let mut buffer = Buffer::new(&mut font_system, metrics);
+    let mut buffer = Buffer::new(&mut font_system);
 
     let mut buffer = buffer.borrow_with(&mut font_system);
 
@@ -30,7 +29,9 @@ fn main() {
     buffer.set_size(width, height);
 
     // Attributes indicate what font to choose
-    let attrs = Attrs::new();
+    let attrs = Attrs::new()
+        .size(FONT_SIZE)
+        .line_height(LineHeight::Absolute(LINE_HEIGHT));
 
     // Add some text!
     let text = std::env::args()

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -57,11 +57,11 @@ impl<'buffer> Editor<'buffer> {
         F: FnMut(i32, i32, u32, u32, Color),
     {
         self.with_buffer(|buffer| {
-            let line_height = buffer.metrics().line_height;
             for run in buffer.layout_runs() {
                 let line_i = run.line_i;
                 let line_y = run.line_y;
                 let line_top = run.line_top;
+                let line_height = run.line_height;
 
                 let cursor_glyph_opt = |cursor: &Cursor| -> Option<(usize, f32)> {
                     if cursor.line == line_i {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -16,6 +16,8 @@ pub struct LayoutGlyph {
     pub end: usize,
     /// Font size of the glyph
     pub font_size: f32,
+    /// Line height
+    pub line_height: f32,
     /// Font id of the glyph
     pub font_id: fontdb::ID,
     /// Font id of the glyph
@@ -95,6 +97,16 @@ pub struct LayoutLine {
     pub max_descent: f32,
     /// Glyphs in line
     pub glyphs: Vec<LayoutGlyph>,
+}
+
+impl LayoutLine {
+    pub fn line_height(&self) -> f32 {
+        self.glyphs
+            .iter()
+            .map(|g| g.line_height)
+            .reduce(f32::max)
+            .unwrap_or_default()
+    }
 }
 
 /// Wrapping mode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! point, you can use the `SwashCache` to rasterize glyphs into either images or pixels.
 //!
 //! ```
-//! use cosmic_text::{Attrs, Color, FontSystem, SwashCache, Buffer, Metrics, Shaping};
+//! use cosmic_text::{Attrs, Buffer, Color, FontSystem, LineHeight, Shaping, SwashCache};
 //!
 //! // A FontSystem provides access to detected system fonts, create one per application
 //! let mut font_system = FontSystem::new();
@@ -20,11 +20,8 @@
 //! // A SwashCache stores rasterized glyphs, create one per application
 //! let mut swash_cache = SwashCache::new();
 //!
-//! // Text metrics indicate the font size and line height of a buffer
-//! let metrics = Metrics::new(14.0, 20.0);
-//!
 //! // A Buffer provides shaping and layout for a UTF-8 string, create one per text widget
-//! let mut buffer = Buffer::new(&mut font_system, metrics);
+//! let mut buffer = Buffer::new(&mut font_system);
 //!
 //! // Borrow buffer together with the font system for more convenient method calls
 //! let mut buffer = buffer.borrow_with(&mut font_system);
@@ -32,8 +29,8 @@
 //! // Set a size for the text buffer, in pixels
 //! buffer.set_size(80.0, 25.0);
 //!
-//! // Attributes indicate what font to choose
-//! let attrs = Attrs::new();
+//! // Attributes indicate what font, font size, line height and other styles to choose
+//! let attrs = Attrs::new().size(14.0).line_height(LineHeight::Proportional(1.2));
 //!
 //! // Add some text!
 //! buffer.set_text("Hello, Rust! 🦀\n", attrs, Shaping::Advanced);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
 use cosmic_text::{
-    fontdb::Database, Attrs, AttrsOwned, Buffer, Color, Family, FontSystem, Metrics, Shaping,
-    SwashCache,
+    fontdb::Database, Attrs, AttrsOwned, Buffer, Color, Family, FontSystem, Shaping, SwashCache,
 };
 use tiny_skia::{Paint, Pixmap, Rect, Transform};
 
@@ -84,15 +83,21 @@ impl DrawTestCfg {
         font_db.load_fonts_dir(fonts_path);
         let mut font_system = FontSystem::new_with_locale_and_db("En-US".into(), font_db);
         let mut swash_cache = SwashCache::new();
-        let metrics = Metrics::new(self.font_size, self.line_height);
-        let mut buffer = Buffer::new(&mut font_system, metrics);
+        let mut buffer = Buffer::new(&mut font_system);
         let mut buffer = buffer.borrow_with(&mut font_system);
         let margins = 5;
         buffer.set_size(
             (self.canvas_width - margins * 2) as f32,
             (self.canvas_height - margins * 2) as f32,
         );
-        buffer.set_text(&self.text, self.font.as_attrs(), Shaping::Advanced);
+        buffer.set_text(
+            &self.text,
+            self.font
+                .as_attrs()
+                .size(self.font_size)
+                .line_height(cosmic_text::LineHeight::Absolute(self.line_height)),
+            Shaping::Advanced,
+        );
         buffer.shape_until_scroll(true);
 
         // Black

--- a/tests/wrap_stability.rs
+++ b/tests/wrap_stability.rs
@@ -1,6 +1,6 @@
 use cosmic_text::{
     fontdb, Align, Attrs, AttrsList, BidiParagraphs, Buffer, Family, FontSystem, LayoutLine,
-    Metrics, ShapeLine, Shaping, Weight, Wrap,
+    ShapeLine, Shaping, Weight, Wrap,
 };
 
 // Test for https://github.com/pop-os/cosmic-text/issues/134
@@ -13,7 +13,8 @@ fn stable_wrap() {
     let attrs = AttrsList::new(
         Attrs::new()
             .family(Family::Name("FiraMono"))
-            .weight(Weight::MEDIUM),
+            .weight(Weight::MEDIUM)
+            .size(font_size),
     );
     let mut font_system =
         FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
@@ -23,11 +24,21 @@ fn stable_wrap() {
     let mut check_wrap = |text: &_, wrap, start_width| {
         let line = ShapeLine::new(&mut font_system, text, &attrs, Shaping::Advanced);
 
-        let layout_unbounded = line.layout(font_size, start_width, wrap, Some(Align::Left), None);
+        let layout_unbounded = line.layout(
+            /*font_size, */ start_width,
+            wrap,
+            Some(Align::Left),
+            None,
+        );
         let max_width = layout_unbounded.iter().map(|l| l.w).fold(0.0, f32::max);
         let new_limit = f32::min(start_width, max_width);
 
-        let layout_bounded = line.layout(font_size, new_limit, wrap, Some(Align::Left), None);
+        let layout_bounded = line.layout(
+            /*font_size, */ new_limit,
+            wrap,
+            Some(Align::Left),
+            None,
+        );
         let bounded_max_width = layout_bounded.iter().map(|l| l.w).fold(0.0, f32::max);
 
         // For debugging:
@@ -74,15 +85,17 @@ fn stable_wrap() {
 #[test]
 fn wrap_extra_line() {
     let mut font_system = FontSystem::new();
-    let metrics = Metrics::new(14.0, 20.0);
+    let attrs = Attrs::new()
+        .family(cosmic_text::Family::Name("Inter"))
+        .size(14.0)
+        .line_height(cosmic_text::LineHeight::Absolute(20.0));
 
-    let mut buffer = Buffer::new(&mut font_system, metrics);
-
+    let mut buffer = Buffer::new(&mut font_system);
     let mut buffer = buffer.borrow_with(&mut font_system);
 
     // Add some text!
     buffer.set_wrap(Wrap::Word);
-    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing\n\nweeewoooo minim sint cillum sint consectetur cupidatat.", Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced);
+    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing\n\nweeewoooo minim sint cillum sint consectetur cupidatat.", attrs, Shaping::Advanced);
 
     // Set a size for the text buffer, in pixels
     buffer.set_size(50.0, 1000.0);

--- a/tests/wrap_word_fallback.rs
+++ b/tests/wrap_word_fallback.rs
@@ -1,18 +1,20 @@
-use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, Wrap};
+use cosmic_text::{Attrs, Buffer, FontSystem, Shaping, Wrap};
 
 // Tests the ability to fallback to glyph wrapping when a word can't fit on a line by itself.
 // No line should ever overflow the buffer size.
 #[test]
 fn wrap_word_fallback() {
     let mut font_system = FontSystem::new();
-    let metrics = Metrics::new(14.0, 20.0);
+    let attrs = Attrs::new()
+        .family(cosmic_text::Family::Name("Inter"))
+        .size(14.0)
+        .line_height(cosmic_text::LineHeight::Absolute(20.0));
 
-    let mut buffer = Buffer::new(&mut font_system, metrics);
-
+    let mut buffer = Buffer::new(&mut font_system);
     let mut buffer = buffer.borrow_with(&mut font_system);
 
     buffer.set_wrap(Wrap::WordOrGlyph);
-    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced);
+    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", attrs, Shaping::Advanced);
     buffer.set_size(50.0, 1000.0);
 
     buffer.shape_until_scroll(false);


### PR DESCRIPTION
Implement specifying multiple font sizes and/or line heights.

- This is https://github.com/pop-os/cosmic-text/pull/203 rebased on top of the recent refactor
- Which was itself continued from https://github.com/pop-os/cosmic-text/pull/150.
- Fixes #64.

### Current status

Basic layout functionality is working, but it needs a bit of a rework (possibly involving some API design work). Additionally, scrolling / editing are not currently working correctly.

### Todo

* [x]  fix scrolling
* [x]  implement `enum LineHeight`
* [x]  cache `line_heights()`
* [x]  retire `Metrics`
* [x]  ~rebase~ `main` merged into branch. Will need to squash prior to merge.
* [x]  migrate tests
* [x]  migrate benches
* [x]  migrate example terminal (NOTE: does not compile on Windows with `termion`, see [Update terminal example using colored` #129](https://github.com/pop-os/cosmic-text/pull/129))
* [ ] Fix:
   * [ ] Empty lines not displaying (due to no styles / line height applying)
   * [ ] Scrolling when buffer is smaller than number of lines (may be a bug in resize / shape functions)
   * [ ] Editor example: fix rescaling font sizes on demand (perhaps via mutable access to spans of Attrs)
   * [ ] Functionality using the `visible_lines` functionality (shape_until_scroll, shape_until_cursor)
   * [ ] Vi Editor
   * [ ] Editor action Vertical (may now be working but need to check)
* [ ] Add:
    * [ ] `scale_factor` field to Buffer (this is necessary to deal with scale factor changes (e.g. when moving windows between displays) ergonomically now that font_size is not buffer-global)
    * [ ] Default `Attrs` for a Buffer
* [ ]  Docs

Questions:

* Should the `Hash` impl of `Attrs` include line height?

