### PR TITLE
bugfix: Handle inverted Ranges in add_span

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -281,8 +281,8 @@ impl AttrsList {
 
     /// Add an attribute span, removes any previous matching parts of spans
     pub fn add_span(&mut self, range: Range<usize>, attrs: Attrs) {
-        //do not support 1..1 even if by accident.
-        if range.start == range.end {
+        //do not support 1..1 or 2..1 even if by accident.
+        if range.is_empty() {
             return;
         }
 


### PR DESCRIPTION
`Range<T>` does not guarantee that `self.start <= self.end`; it is perfectly valid for `self.start > self.range`, the Range is just considered to be empty in this case. We can use the `is_empty()` method to filter out these empty Ranges as they do not make sense here.

Note that `RangeMap` asserts that `self.start < self.end` so filtering here cannot break any existing code that would be relying on "inverted ranges". Changing the filtering can only make a panic into a no-op.