### PR TITLE
Enable vi feature for docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ criterion = { version = "0.5.1", default-features = false, features = [
 
 [profile.test]
 opt-level = 1
+
+[package.metadata.docs.rs]
+features = ["vi"]


### PR DESCRIPTION
This should be pretty self-explanatory. Enables the docs for the feature to show on docs.rs.