### PR TITLE
Port `rich-text` example to winit

### DIFF
--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
 
     let mut display_scale = window.scale_factor() as f32;
 
+    let scrollbar_width = 12.0;
     let font_sizes = [
         Metrics::new(10.0, 14.0), // Caption
         Metrics::new(14.0, 20.0), // Body
@@ -39,8 +40,6 @@ fn main() {
     ];
     let font_size_default = 1; // Body
     let mut font_size_i = font_size_default;
-
-    let line_x = 8.0 * (window.scale_factor() as f32);
 
     let mut editor = SyntaxEditor::new(
         Buffer::new(
@@ -110,8 +109,10 @@ fn main() {
                             pixmap.fill(tiny_skia::Color::from_rgba8(0, 0, 0, 0xFF));
 
                             editor.with_buffer_mut(|buffer| {
-                                buffer
-                                    .set_size(width as f32 - line_x * display_scale, height as f32)
+                                buffer.set_size(
+                                    width as f32 - scrollbar_width * display_scale,
+                                    height as f32,
+                                )
                             });
 
                             let mut paint = Paint::default();
@@ -151,9 +152,9 @@ fn main() {
                                 if end_y > start_y {
                                     pixmap.fill_rect(
                                         Rect::from_xywh(
-                                            width as f32 - line_x * display_scale,
+                                            width as f32 - scrollbar_width * display_scale,
                                             start_y as f32,
-                                            line_x * display_scale,
+                                            scrollbar_width * display_scale,
                                             (end_y - start_y) as f32,
                                         )
                                         .unwrap(),
@@ -296,7 +297,7 @@ fn main() {
                                     && mouse_left == ElementState::Released
                                 {
                                     editor.action(Action::Click {
-                                        x: mouse_x /*- line_x*/ as i32,
+                                        x: mouse_x as i32,
                                         y: mouse_y as i32,
                                     });
                                     window.request_redraw();

--- a/examples/rich-text/Cargo.toml
+++ b/examples/rich-text/Cargo.toml
@@ -7,8 +7,11 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-cosmic-text = { path = "../../" }
+cosmic-text = { path = "../.." }
 env_logger = "0.10"
 fontdb = "0.13"
 log = "0.4"
-orbclient = "0.3.35"
+softbuffer = "0.4"
+tiny-skia = "0.11"
+unicode-segmentation = "1.7"
+winit = "0.29"


### PR DESCRIPTION
Followup to #239. Boilerplate between editor and rich-text examples is very similar and they could possibly be combined at some point, but for now I've left them separate. Remaining differences:

- `editor` uses `SyntaxEditor` (or optional `ViEditor`). `rich-text` uses a plain `Editor`.
- `editor` loads content from file. `rich-text` hard codes content.
- Draw commands differ slightly due to differences between `Editor` and `SyntaxEditor`
- `rich-text` doesn't draw a scrollbar (it could, but scrollbar code needs to be tightened up to deal with case where content is shorter than window).