### PR TITLE
Faster mono fallback

### DIFF
--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -173,24 +173,21 @@ impl<'a> Iterator for FontFallbackIter<'a> {
                 }
                 // Set a monospace fallback if Monospace family is not found
                 if is_mono {
-                    if let Some(face_info) = self.font_system.db().face(m_key.id) {
-                        // Don't use emoji fonts as Monospace
-                        if face_info.monospaced && !face_info.post_script_name.contains("Emoji") {
-                            let supported_cp_count_opt = self
-                                .font_system
-                                .get_font_supported_codepoints_in_word(m_key.id, self.word);
-                            if let Some(supported_cp_count) = supported_cp_count_opt {
-                                let codepoint_non_matches =
-                                    self.word.chars().count() - supported_cp_count;
+                    if self.font_system.is_monospace(m_key.id) {
+                        let supported_cp_count_opt = self
+                            .font_system
+                            .get_font_supported_codepoints_in_word(m_key.id, self.word);
+                        if let Some(supported_cp_count) = supported_cp_count_opt {
+                            let codepoint_non_matches =
+                                self.word.chars().count() - supported_cp_count;
 
-                                let fallback_info = MonospaceFallbackInfo {
-                                    font_weight_diff: Some(m_key.font_weight_diff),
-                                    codepoint_non_matches: Some(codepoint_non_matches),
-                                    font_weight: m_key.font_weight,
-                                    id: m_key.id,
-                                };
-                                assert!(self.monospace_fallbacks.insert(fallback_info));
-                            }
+                            let fallback_info = MonospaceFallbackInfo {
+                                font_weight_diff: Some(m_key.font_weight_diff),
+                                codepoint_non_matches: Some(codepoint_non_matches),
+                                font_weight: m_key.font_weight,
+                                id: m_key.id,
+                            };
+                            assert!(self.monospace_fallbacks.insert(fallback_info));
                         }
                     }
                 }

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -176,15 +176,12 @@ impl<'a> Iterator for FontFallbackIter<'a> {
                     if let Some(face_info) = self.font_system.db().face(m_key.id) {
                         // Don't use emoji fonts as Monospace
                         if face_info.monospaced && !face_info.post_script_name.contains("Emoji") {
-                            if let Some(font) = self.font_system.get_font(m_key.id) {
-                                let codepoint_non_matches = self.word.chars().count()
-                                    - self
-                                        .word
-                                        .chars()
-                                        .filter(|ch| {
-                                            font.unicode_codepoints().contains(&u32::from(*ch))
-                                        })
-                                        .count();
+                            let supported_cp_count_opt = self
+                                .font_system
+                                .get_font_supported_codepoints_in_word(m_key.id, self.word);
+                            if let Some(supported_cp_count) = supported_cp_count_opt {
+                                let codepoint_non_matches =
+                                    self.word.chars().count() - supported_cp_count;
 
                                 let fallback_info = MonospaceFallbackInfo {
                                     font_weight_diff: Some(m_key.font_weight_diff),

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -86,6 +86,9 @@ pub struct FontSystem {
     /// Cache for loaded fonts from the database.
     font_cache: HashMap<fontdb::ID, Option<Arc<Font>>>,
 
+    /// Sorted unique ID's of all Monospace fonts in DB
+    monospace_font_ids: Vec<fontdb::ID>,
+
     /// Cache for font codepoint support info
     font_codepoint_support_info_cache: HashMap<fontdb::ID, FontCachedCodepointSupportInfo>,
 
@@ -141,9 +144,19 @@ impl FontSystem {
 
     /// Create a new [`FontSystem`] with a pre-specified locale and font database.
     pub fn new_with_locale_and_db(locale: String, db: fontdb::Database) -> Self {
+        let mut monospace_font_ids = db
+            .faces()
+            .filter(|face_info| {
+                face_info.monospaced && !face_info.post_script_name.contains("Emoji")
+            })
+            .map(|face_info| face_info.id)
+            .collect::<Vec<_>>();
+        monospace_font_ids.sort();
+
         Self {
             locale,
             db,
+            monospace_font_ids,
             font_cache: Default::default(),
             font_matches_cache: Default::default(),
             font_codepoint_support_info_cache: Default::default(),
@@ -200,6 +213,10 @@ impl FontSystem {
                 }
             })
             .clone()
+    }
+
+    pub fn is_monospace(&self, id: fontdb::ID) -> bool {
+        self.monospace_font_ids.binary_search(&id).is_ok()
     }
 
     #[inline(always)]


### PR DESCRIPTION
* Cache codepoint support info for monospace fonts.
* Only try monospace fonts that support at least one requested script:
  * Codepoint support info is still collected for these fonts to guide
 the fallback order selection process.
  * A map of per-script monospace font-ids is pre-populated in font system
 to acquire lists of wanted font ids efficiently.
  * This gives an important performance boost when scripts are involved.
* Skip trying monospace fallbacks if the default font supports all codepoints.
  * Actually collect codepoint support info for the default font.
  * If it supports all codepoints, skip collecting that info from other
 monospace fonts.
  * Biggest performance improvement comes from this change, doubly so for users that only need the default font.

With all these changes, and with the relatively common single space word " ", monospace fallback process will go from:

* Checking for `space` codepoint support in all monospace fonts (except default font) using `slice::contains()`.
* Selecting default font first to try shaping with, which should work, unless it's a very unusual choice.

To the new process of:

* Checking for `space` codepoint support in default font.
  * `space` should be found quickly via a binary search in `FontCachedCodepointSupportInfo`.
* Selecting default font to try shaping with, which should work since we already checked that it does support `space`.



Should help with pop-os/cosmic-term#130.  
May or may not fully or partially solve pop-os/cosmic-term#155.