### PR TITLE
Fix: Undo and redo correctly updates editor modified status

### DIFF
--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -53,7 +53,7 @@ fn eval_changed(commands: &cosmic_undo_2::Commands<Change>, pivot: Pivot) -> boo
         .current_command_index()
         .map(|current| match pivot {
             Pivot::Unsaved => true,
-            Pivot::Exact(i) => current == i,
+            Pivot::Exact(i) => current != i,
             Pivot::Saved => false,
         })
         .unwrap_or(true)
@@ -279,6 +279,7 @@ impl<'syntax_system, 'buffer> ViEditor<'syntax_system, 'buffer> {
             Pivot::Saved => Pivot::Exact(self.commands.current_command_index().unwrap_or_default()),
             _ => pivot,
         };
+        self.changed = eval_changed(&self.commands, pivot);
     }
 
     /// Set passthrough mode (true will turn off vi features)

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -46,6 +46,7 @@ fn finish_change<'buffer, E: Edit<'buffer>>(
     }
 }
 
+/// Evaluate if an [`ViEditor`] changed based on its last saved state.
 fn eval_changed(commands: &cosmic_undo_2::Commands<Change>, pivot: Option<usize>) -> bool {
     // Editors are considered modified if the current change index is unequal to the last
     // saved index or if `pivot` is None.
@@ -250,15 +251,15 @@ impl<'syntax_system, 'buffer> ViEditor<'syntax_system, 'buffer> {
         self.changed = changed;
     }
 
-    /// Set last saved pivot point
+    /// Set current change as the save (or pivot) point.
     ///
     /// A pivot point is the last saved index. Anything before or after the pivot indicates that
     /// the editor has been changed or is unsaved.
     ///
-    /// The pivot point for an unsaved editor is `0`. In other words, all changes are unsaved.
-    /// The pivot point for a saved editor is the index of the last change - 1.
+    /// Undoing changes down to the pivot point sets the editor as unchanged.
+    /// Redoing changes up to the pivot point sets the editor as unchanged.
     ///
-    /// Undoing changes down to the pivot point means that the editor is unchanged.
+    /// Undoing or redoing changes beyond the pivot point sets the editor to changed.
     pub fn save_point(&mut self) {
         self.save_pivot = Some(self.commands.current_command_index().unwrap_or_default());
         self.changed = false;

--- a/tests/editor_modified_state.rs
+++ b/tests/editor_modified_state.rs
@@ -1,9 +1,12 @@
+#![cfg(feature = "vi")]
+
 use std::sync::OnceLock;
 
-use cosmic_text::{Buffer, Change, Cursor, Edit, Metrics, SyntaxEditor, SyntaxSystem, ViEditor};
+use cosmic_text::{Buffer, Cursor, Edit, Metrics, SyntaxEditor, SyntaxSystem, ViEditor};
 
 static SYNTAX_SYSTEM: OnceLock<SyntaxSystem> = OnceLock::new();
 
+// New editor for tests
 fn editor() -> ViEditor<'static, 'static> {
     // More or less copied from cosmic-edit
     let font_size: f32 = 14.0;
@@ -33,6 +36,8 @@ fn insert_in_empty_editor_sets_changed() {
     assert!(editor.changed());
 }
 
+// Tests an edge case where a save point is never set.
+// Undoing changes should set the editor back to unmodified.
 #[test]
 fn insert_and_undo_in_unsaved_editor_is_unchanged() {
     let mut editor = editor();
@@ -51,32 +56,41 @@ fn insert_and_undo_in_unsaved_editor_is_unchanged() {
 }
 
 #[test]
-fn undo_to_last_save() {
+fn undo_to_save_point_sets_editor_to_unchanged() {
     let mut editor = editor();
 
     // Latest saved change is the first change
     editor.start_change();
     let cursor = editor.insert_at(Cursor::new(0, 0), "Ferris is Rust's ", None);
     editor.finish_change();
-    assert!(editor.changed());
+    assert!(
+        editor.changed(),
+        "Editor should be set to changed after insertion"
+    );
     editor.save_point();
-    // assert_eq!(Pivot::Saved, editor.save_pivot());
-    assert!(!editor.changed());
+    assert!(
+        !editor.changed(),
+        "Editor should be set to unchanged after setting a save point"
+    );
 
     // A new insert should set the editor as modified and the pivot should still be on the first
     // change from earlier
     editor.start_change();
     editor.insert_at(cursor, "mascot", None);
     editor.finish_change();
-    // assert_eq!(Pivot::Exact(0), editor.save_pivot());
-    assert!(editor.changed());
+    assert!(
+        editor.changed(),
+        "Editor should be set to changed after inserting text after a save point"
+    );
 
     // Undoing the latest change should set the editor to unmodified again
     editor.start_change();
     editor.undo();
     editor.finish_change();
-    // assert_eq!(Pivot::Saved, editor.save_pivot());
-    assert!(!editor.changed());
+    assert!(
+        !editor.changed(),
+        "Editor should be set to unchanged after undoing to save point"
+    );
 }
 
 #[test]
@@ -128,11 +142,86 @@ fn redoing_to_save_point_sets_editor_as_unchanged() {
 }
 
 #[test]
-fn redoing_past_save_point_sets_editor_as_changed() {
-    unimplemented!()
+fn redoing_past_save_point_sets_editor_to_changed() {
+    let mut editor = editor();
+
+    // Save point change to undo to and then redo past.
+    editor.start_change();
+    editor.insert_string("Walt Whitman ", None);
+    editor.finish_change();
+
+    // Set save point to the change above.
+    assert!(
+        editor.changed(),
+        "Editor should be set as modified after insert() and finish_change()"
+    );
+    editor.save_point();
+    assert!(
+        !editor.changed(),
+        "Editor should be unchanged after setting a save point"
+    );
+
+    editor.start_change();
+    editor.insert_string("Allen Ginsberg ", None);
+    editor.finish_change();
+
+    editor.start_change();
+    editor.insert_string("Jack Kerouac ", None);
+    editor.finish_change();
+
+    assert!(editor.changed(), "Editor should be modified insertion");
+
+    // Undo to Whitman
+    editor.undo();
+    editor.undo();
+    assert!(
+        !editor.changed(),
+        "Editor should be unmodified after undoing to the save point"
+    );
+
+    // Redo to Kerouac
+    editor.redo();
+    editor.redo();
+    assert!(
+        editor.changed(),
+        "Editor should be modified after redoing past the save point"
+    );
 }
 
 #[test]
-fn undo_all_changes() {
-    unimplemented!()
+fn undoing_past_save_point_sets_editor_to_changed() {
+    let mut editor = editor();
+
+    editor.start_change();
+    editor.insert_string("Robert Fripp ", None);
+    editor.finish_change();
+
+    // Save point change to undo past.
+    editor.start_change();
+    editor.insert_string("Thurston Moore ", None);
+    editor.finish_change();
+
+    assert!(editor.changed(), "Editor should be changed after insertion");
+    editor.save_point();
+    assert!(
+        !editor.changed(),
+        "Editor should be unchanged after setting a save point"
+    );
+
+    editor.start_change();
+    editor.insert_string("Kim Deal ", None);
+    editor.finish_change();
+
+    // Undo to the first change
+    editor.undo();
+    editor.undo();
+    assert!(
+        editor.changed(),
+        "Editor should be changed after undoing past save point"
+    );
 }
+
+// #[test]
+// fn undo_all_changes() {
+//     unimplemented!()
+// }

--- a/tests/editor_modified_state.rs
+++ b/tests/editor_modified_state.rs
@@ -1,0 +1,53 @@
+use std::sync::OnceLock;
+
+use cosmic_text::{
+    Buffer, Change, Cursor, Edit, Metrics, Pivot, SyntaxEditor, SyntaxSystem, ViEditor,
+};
+
+static SYNTAX_SYSTEM: OnceLock<SyntaxSystem> = OnceLock::new();
+
+fn editor() -> ViEditor<'static, 'static> {
+    // More or less copied from cosmic-edit
+    let font_size: f32 = 14.0;
+    let line_height = (font_size * 1.4).ceil();
+
+    let metrics = Metrics::new(font_size, line_height);
+    let buffer = Buffer::new_empty(metrics);
+    let editor = SyntaxEditor::new(
+        buffer,
+        SYNTAX_SYSTEM.get_or_init(SyntaxSystem::new),
+        "base16-eighties.dark",
+    )
+    .expect("Default theme `base16-eighties.dark` should be found");
+
+    ViEditor::new(editor)
+}
+
+#[test]
+fn undo_to_last_save() {
+    let mut editor = editor();
+
+    // Latest saved change is the first change
+    editor.start_change();
+    let cursor = editor.insert_at(Cursor::new(0, 0), "Ferris is Rust's ", None);
+    editor.finish_change();
+    assert!(editor.changed());
+    editor.set_save_pivot(Pivot::Saved);
+    assert_eq!(Pivot::Saved, editor.save_pivot());
+    assert!(!editor.changed());
+
+    // A new insert should set the editor as modified and the pivot should still be on the first
+    // change from earlier
+    editor.start_change();
+    editor.insert_at(cursor, "mascot", None);
+    editor.finish_change();
+    assert_eq!(Pivot::Exact(0), editor.save_pivot());
+    assert!(editor.changed());
+
+    // Undoing the latest change should set the editor to unmodified again
+    editor.start_change();
+    editor.undo();
+    editor.finish_change();
+    assert_eq!(Pivot::Saved, editor.save_pivot());
+    assert!(!editor.changed());
+}

--- a/tests/editor_modified_state.rs
+++ b/tests/editor_modified_state.rs
@@ -34,6 +34,23 @@ fn insert_in_empty_editor_sets_changed() {
 }
 
 #[test]
+fn insert_and_undo_in_unsaved_editor_is_unchanged() {
+    let mut editor = editor();
+
+    assert!(!editor.changed());
+    editor.start_change();
+    editor.insert_at(Cursor::new(0, 0), "loop {}", None);
+    editor.finish_change();
+    assert!(editor.changed());
+
+    // Undoing the above change should set the editor as unchanged even if the save state is unset
+    editor.start_change();
+    editor.undo();
+    editor.finish_change();
+    assert!(!editor.changed());
+}
+
+#[test]
 fn undo_to_last_save() {
     let mut editor = editor();
 
@@ -60,4 +77,62 @@ fn undo_to_last_save() {
     editor.finish_change();
     // assert_eq!(Pivot::Saved, editor.save_pivot());
     assert!(!editor.changed());
+}
+
+#[test]
+fn redoing_to_save_point_sets_editor_as_unchanged() {
+    let mut editor = editor();
+
+    // Initial change
+    assert!(
+        !editor.changed(),
+        "Editor should start in an unchanged state"
+    );
+    editor.start_change();
+    editor.insert_at(Cursor::new(0, 0), "editor.start_change();", None);
+    editor.finish_change();
+    assert!(
+        editor.changed(),
+        "Editor should be set as modified after insert() and finish_change()"
+    );
+    editor.save_point();
+    assert!(
+        !editor.changed(),
+        "Editor should be unchanged after setting a save point"
+    );
+
+    // Change to undo then redo
+    editor.start_change();
+    editor.insert_at(Cursor::new(1, 0), "editor.finish_change()", None);
+    editor.finish_change();
+    assert!(
+        editor.changed(),
+        "Editor should be set as modified after insert() and finish_change()"
+    );
+    editor.save_point();
+    assert!(
+        !editor.changed(),
+        "Editor should be unchanged after setting a save point"
+    );
+
+    editor.undo();
+    assert!(
+        editor.changed(),
+        "Undoing past save point should set editor as changed"
+    );
+    editor.redo();
+    assert!(
+        !editor.changed(),
+        "Redoing to save point should set editor as unchanged"
+    );
+}
+
+#[test]
+fn redoing_past_save_point_sets_editor_as_changed() {
+    unimplemented!()
+}
+
+#[test]
+fn undo_all_changes() {
+    unimplemented!()
 }


### PR DESCRIPTION
Related to two issues on [cosmic-edit](https://github.com/pop-os/cosmic-edit/):
* [#116](https://github.com/pop-os/cosmic-edit/issues/116)
* [#128](https://github.com/pop-os/cosmic-edit/issues/128) - I will work on 128 on a separate PR, but the code here is related to it.

I implemented a fix for two `TODO`s related to the issues above. Prior to this patch, undoing and redoing changes don't unset the editor's changed flag. The editor seems to be always marked as changed unless manually set to unchanged.

I fixed this issue by adding a save point to the editor which sets the current change to the last saved state. Undoing or redoing past this change correctly sets the editor as modified. Undoing or redoing TO the save point sets the editor as unmodified.

I wrote several unit tests to validate the behavior above - they're likely clearer than my explanation above. :joy_cat: