### PR TITLE
Promote Noto Color Emoji fallback

### DIFF
--- a/src/font/fallback/unix.rs
+++ b/src/font/fallback/unix.rs
@@ -8,9 +8,11 @@ pub fn common_fallback() -> &'static [&'static str] {
     &[
         /* Sans-serif fallbacks */
         "Noto Sans",
+        "FreeSans",
+        /* Emoji fallbacks*/
+        "Noto Color Emoji",
         /* More sans-serif fallbacks */
         "DejaVu Sans",
-        "FreeSans",
         /* Mono fallbacks */
         "Noto Sans Mono",
         "DejaVu Sans Mono",
@@ -18,8 +20,6 @@ pub fn common_fallback() -> &'static [&'static str] {
         /* Symbols fallbacks */
         "Noto Sans Symbols",
         "Noto Sans Symbols2",
-        /* Emoji fallbacks*/
-        "Noto Color Emoji",
         //TODO: Add CJK script here for doublewides?
     ]
 }


### PR DESCRIPTION
Helps with https://github.com/pop-os/cosmic-text/issues/227

The DejaVu Sans font includes some emoji glyphs, so I moved it after Noto Color Emoji in the fallback  order.

For some reason the smiling face emoji still isn't correct, but rendering of other emojis has been fixed.
![image](https://github.com/pop-os/cosmic-text/assets/71973804/095cc71c-48fb-4e06-abb6-29b4cea56c5c)
