### PR TITLE
Hide cursor based on selection, preedit, or config

### DIFF
--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -203,8 +203,32 @@ pub trait Edit<'buffer> {
     /// Get the current cursor
     fn cursor(&self) -> Cursor;
 
+    /// Hide or show the cursor
+    ///
+    /// This should be used to hide the cursor, for example,
+    /// when the editor is unfocused, when the text is not editable,
+    /// or to implement cursor blinking.
+    ///
+    /// Note that even after `set_cursor_hidden(false)`, the editor may
+    /// choose to hide the cursor based on internal state, for example,
+    /// when there is a selection or when there is a preedit without a cursor.
+    fn set_cursor_hidden(&mut self, hidden: bool);
+
     /// Set the current cursor
     fn set_cursor(&mut self, cursor: Cursor);
+
+    /// Returns true if some text is selected
+    fn has_selection(&self) -> bool {
+        match self.selection() {
+            Selection::None => false,
+            Selection::Normal(selection) => {
+                let cursor = self.cursor();
+                selection.line != cursor.line || selection.index != cursor.index
+            }
+            Selection::Line(selection) => selection.line != self.cursor().line,
+            Selection::Word(_) => true,
+        }
+    }
 
     /// Get the current selection position
     fn selection(&self) -> Selection;

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -256,6 +256,10 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for SyntaxEditor<'syntax_system, 'bu
         self.editor.selection()
     }
 
+    fn set_cursor_hidden(&mut self, hidden: bool) {
+        self.editor.set_cursor_hidden(hidden);
+    }
+
     fn set_selection(&mut self, selection: Selection) {
         self.editor.set_selection(selection);
     }

--- a/src/edit/vi.rs
+++ b/src/edit/vi.rs
@@ -1165,6 +1165,10 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for ViEditor<'syntax_system, 'buffer
     fn cursor_position(&self) -> Option<(i32, i32)> {
         self.editor.cursor_position()
     }
+
+    fn set_cursor_hidden(&mut self, hidden: bool) {
+        self.editor.set_cursor_hidden(hidden);
+    }
 }
 
 impl<'font_system, 'syntax_system, 'buffer>


### PR DESCRIPTION
1. Cursor is now hidden when there is a selection.
2. Cursor is now hidden when there is an IME preedit that specifies that there should be no cursor.
3. Added `Edit::set_cursor_hidden()` to hide cursor manually, which can be used to implement cursor blinking, and to hide cursor when the input is unfocused or read only.

While I generally prefer "positive" boolean flags (e.g. `set_cursor_visible()` would generally be better), in this case the logic looks simpler when we use the `hidden` flag: `cursor_hidden = has_selection || has_preedit_without_cursor || set_cursor_hidden`.
