### PR TITLE
Upgrade dependencies, and re-export ttf-parser 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ rust-version = "1.65"
 [dependencies]
 bitflags = "2.4.1"
 cosmic_undo_2 = { version = "0.2.0", optional = true }
-fontdb = { version = "0.16.0", default-features = false }
+fontdb = { version = "0.18", default-features = false }
 hashbrown = { version = "0.14.1", optional = true, default-features = false }
 libm = { version = "0.2.8", optional = true }
 log = "0.4.20"
 modit = { version = "0.1.4", optional = true }
 rangemap = "1.4.0"
 rustc-hash = { version = "1.1.0", default-features = false }
-rustybuzz = { version = "0.12.0", default-features = false, features = ["libm"] }
+rustybuzz = { version = "0.14.0", default-features = false, features = ["libm"] }
 self_cell = "1.0.1"
 swash = { version = "0.1.12", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
-ttf-parser = { version = "0.20.0", default-features = false }
+ttf-parser = { version = "0.21", default-features = false }
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.1"

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pub(crate) mod fallback;
 
+// re-export ttf_parser
+pub use ttf_parser;
+
 use core::fmt;
 
 use alloc::sync::Arc;


### PR DESCRIPTION
so that dependents can verify fonts using the same ttf-parser version ( for usage in bevy asset font loader for example )