### PR TITLE
implement Clone for Editor

### DIFF
--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// A wrapper of [`Buffer`] for easy editing
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Editor<'buffer> {
     buffer_ref: BufferRef<'buffer>,
     cursor: Cursor,

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -75,7 +75,7 @@ impl<'buffer> Clone for BufferRef<'buffer> {
     fn clone(&self) -> Self {
         match self {
             Self::Owned(buffer) => Self::Owned(buffer.clone()),
-            Self::Borrowed(buffer) => Self::Owned((*buffer).to_owned()),
+            Self::Borrowed(buffer) => Self::Owned((*buffer).clone()),
             Self::Arc(buffer) => Self::Arc(buffer.clone()),
         }
     }

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -71,6 +71,16 @@ pub enum BufferRef<'buffer> {
     Arc(Arc<Buffer>),
 }
 
+impl<'buffer> Clone for BufferRef<'buffer> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Owned(buffer) => Self::Owned(buffer.clone()),
+            Self::Borrowed(buffer) => Self::Owned((*buffer).to_owned()),
+            Self::Arc(buffer) => Self::Arc(buffer.clone()),
+        }
+    }
+}
+
 impl<'buffer> From<Buffer> for BufferRef<'buffer> {
     fn from(buffer: Buffer) -> Self {
         Self::Owned(buffer)


### PR DESCRIPTION
This PR closes #283.

The only mentionable to this PR is that BufferRef::Borrowed is converted to BufferRef::Owned when cloning. 
```rs
impl<'buffer> Clone for BufferRef<'buffer> {
    fn clone(&self) -> Self {
        match self {
            Self::Owned(buffer) => Self::Owned(buffer.clone()),
            Self::Borrowed(buffer) => Self::Owned((*buffer).to_owned()),
            Self::Arc(buffer) => Self::Arc(buffer.clone()),
        }
    }
}
```