### PR TITLE
Update fontdb, rustybuzz, and ttf-parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ rust-version = "1.65"
 [dependencies]
 bitflags = "2.4.1"
 cosmic_undo_2 = { version = "0.2.0", optional = true }
-fontdb = { version = "0.16", default-features = false }
+fontdb = { version = "0.21", default-features = false }
 hashbrown = { version = "0.14.1", optional = true, default-features = false }
 libm = { version = "0.2.8", optional = true }
 log = "0.4.20"
 modit = { version = "0.1.4", optional = true }
 rangemap = "1.4.0"
 rustc-hash = { version = "1.1.0", default-features = false }
-rustybuzz = { version = "0.14", default-features = false, features = ["libm"] }
+rustybuzz = { version = "0.17", default-features = false }
 self_cell = "1.0.1"
 swash = { version = "0.1.17", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }
-ttf-parser = { version = "0.21", default-features = false }
+ttf-parser = { version = "0.24", default-features = false }
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.1"
@@ -39,7 +39,7 @@ features = ["hardcoded-data"]
 default = ["std", "swash", "fontconfig"]
 fontconfig = ["fontdb/fontconfig", "std"]
 monospace_fallback = []
-no_std = ["rustybuzz/libm", "hashbrown", "dep:libm"]
+no_std = ["hashbrown", "dep:libm"]
 shape-run-cache = []
 std = [
     "fontdb/memmap",


### PR DESCRIPTION
fontdb 0.21 is an update that resolves the symlink regression.