### PR TITLE
Small optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rangemap = "1.4.0"
 rustc-hash = { version = "1.1.0", default-features = false }
 rustybuzz = { version = "0.14", default-features = false, features = ["libm"] }
 self_cell = "1.0.1"
+smol_str = { version = "0.2.2", default-features = false }
 swash = { version = "0.1.17", optional = true }
 syntect = { version = "5.1.0", optional = true }
 sys-locale = { version = "0.3.1", optional = true }

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 #[cfg(not(feature = "std"))]
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::vec::Vec;
 use core::ops::Range;
 use rangemap::RangeMap;
+use smol_str::SmolStr;
 
 use crate::{CacheKeyFlags, Metrics};
 
@@ -69,7 +67,7 @@ impl Color {
 /// An owned version of [`Family`]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum FamilyOwned {
-    Name(String),
+    Name(SmolStr),
     Serif,
     SansSerif,
     Cursive,
@@ -80,7 +78,7 @@ pub enum FamilyOwned {
 impl FamilyOwned {
     pub fn new(family: Family) -> Self {
         match family {
-            Family::Name(name) => FamilyOwned::Name(name.to_string()),
+            Family::Name(name) => FamilyOwned::Name(SmolStr::from(name)),
             Family::Serif => FamilyOwned::Serif,
             Family::SansSerif => FamilyOwned::SansSerif,
             Family::Cursive => FamilyOwned::Cursive,

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -306,7 +306,12 @@ impl AttrsList {
 
     /// Get the current attribute spans
     pub fn spans(&self) -> Vec<(&Range<usize>, &AttrsOwned)> {
-        self.spans.iter().collect()
+        self.spans_iter().collect()
+    }
+
+    /// Get an iterator over the current attribute spans
+    pub fn spans_iter(&self) -> impl Iterator<Item = (&Range<usize>, &AttrsOwned)> + '_ {
+        self.spans.iter()
     }
 
     /// Clear the current attribute spans

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -144,7 +144,7 @@ impl BufferLine {
                 .add_span(len..len + other.text().len(), other.attrs_list.defaults());
         }
 
-        for (other_range, attrs) in other.attrs_list.spans() {
+        for (other_range, attrs) in other.attrs_list.spans_iter() {
             // Add previous attrs spans
             let range = other_range.start + len..other_range.end + len;
             self.attrs_list.add_span(range, attrs.as_attrs());


### PR DESCRIPTION
- Use `SmolStr` instead of `String` in `FamilyOwned`. Families are almost always <= 23 bytes. Note that `SmolStr` is `no-std` when default features are off.
- Add `AttrsList::spans_iter` to avoid an unnecessary allocation in `Buffer::append`.