### PR TITLE
Move ShapeBuffer to FontSystem

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
 use core::{cmp, fmt};
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
 use core::mem;
 
 use crate::{

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -1,10 +1,7 @@
-#[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
 use core::mem;
 
 use crate::{
-    Align, Attrs, AttrsList, Cached, FontSystem, LayoutLine, LineEnding, ShapeBuffer, ShapeLine,
-    Shaping, Wrap,
+    Align, Attrs, AttrsList, Cached, FontSystem, LayoutLine, LineEnding, ShapeLine, Shaping, Wrap,
 };
 
 /// A line (or paragraph) of text that is shaped and laid out
@@ -205,23 +202,12 @@ impl BufferLine {
 
     /// Shape line, will cache results
     pub fn shape(&mut self, font_system: &mut FontSystem, tab_width: u16) -> &ShapeLine {
-        self.shape_in_buffer(&mut ShapeBuffer::default(), font_system, tab_width)
-    }
-
-    /// Shape a line using a pre-existing shape buffer, will cache results
-    pub fn shape_in_buffer(
-        &mut self,
-        scratch: &mut ShapeBuffer,
-        font_system: &mut FontSystem,
-        tab_width: u16,
-    ) -> &ShapeLine {
         if self.shape_opt.is_unused() {
             let mut line = self
                 .shape_opt
                 .take_unused()
                 .unwrap_or_else(ShapeLine::empty);
-            line.build_in_buffer(
-                scratch,
+            line.build(
                 font_system,
                 &self.text,
                 &self.attrs_list,
@@ -249,37 +235,15 @@ impl BufferLine {
         match_mono_width: Option<f32>,
         tab_width: u16,
     ) -> &[LayoutLine] {
-        self.layout_in_buffer(
-            &mut ShapeBuffer::default(),
-            font_system,
-            font_size,
-            width_opt,
-            wrap,
-            match_mono_width,
-            tab_width,
-        )
-    }
-
-    /// Layout a line using a pre-existing shape buffer, will cache results
-    pub fn layout_in_buffer(
-        &mut self,
-        scratch: &mut ShapeBuffer,
-        font_system: &mut FontSystem,
-        font_size: f32,
-        width_opt: Option<f32>,
-        wrap: Wrap,
-        match_mono_width: Option<f32>,
-        tab_width: u16,
-    ) -> &[LayoutLine] {
         if self.layout_opt.is_unused() {
             let align = self.align;
             let mut layout = self
                 .layout_opt
                 .take_unused()
                 .unwrap_or_else(|| Vec::with_capacity(1));
-            let shape = self.shape_in_buffer(scratch, font_system, tab_width);
+            let shape = self.shape(font_system, tab_width);
             shape.layout_to_buffer(
-                scratch,
+                &mut font_system.shape_buffer,
                 font_size,
                 width_opt,
                 wrap,

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use fontdb::Family;
 use unicode_script::Script;
 
-use crate::{Font, FontMatchKey, FontSystem, ShapePlanCache};
+use crate::{Font, FontMatchKey, FontSystem, ShapeBuffer, ShapePlanCache};
 
 use self::platform::*;
 
@@ -119,8 +119,11 @@ impl<'a> FontFallbackIter<'a> {
         }
     }
 
-    pub fn shape_plan_cache(&mut self) -> &mut ShapePlanCache {
-        self.font_system.shape_plan_cache()
+    pub fn shape_caches(&mut self) -> (&mut ShapeBuffer, &mut ShapePlanCache) {
+        (
+            &mut self.font_system.shape_buffer,
+            &mut self.font_system.shape_plan_cache,
+        )
     }
 
     fn face_contains_family(&self, id: fontdb::ID, family_name: &str) -> bool {

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -1,4 +1,4 @@
-use crate::{Attrs, Font, FontMatchAttrs, HashMap, ShapePlanCache};
+use crate::{Attrs, Font, FontMatchAttrs, HashMap, ShapeBuffer, ShapePlanCache};
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -101,7 +101,10 @@ pub struct FontSystem {
     font_matches_cache: HashMap<FontMatchAttrs, Arc<Vec<FontMatchKey>>>,
 
     /// Cache for rustybuzz shape plans.
-    shape_plan_cache: ShapePlanCache,
+    pub(crate) shape_plan_cache: ShapePlanCache,
+
+    /// Scratch buffer for shaping and laying out.
+    pub(crate) shape_buffer: ShapeBuffer,
 
     /// Cache for shaped runs
     #[cfg(feature = "shape-run-cache")]
@@ -171,6 +174,7 @@ impl FontSystem {
             shape_plan_cache: ShapePlanCache::default(),
             #[cfg(feature = "shape-run-cache")]
             shape_run_cache: crate::ShapeRunCache::default(),
+            shape_buffer: ShapeBuffer::default(),
         };
         ret.cache_fonts(cloned_monospace_font_ids.clone());
         cloned_monospace_font_ids.into_iter().for_each(|id| {
@@ -194,11 +198,6 @@ impl FontSystem {
     /// Get the database.
     pub fn db(&self) -> &fontdb::Database {
         &self.db
-    }
-
-    /// Get the shape plan cache.
-    pub(crate) fn shape_plan_cache(&mut self) -> &mut ShapePlanCache {
-        &mut self.shape_plan_cache
     }
 
     /// Get a mutable reference to the database.


### PR DESCRIPTION
`ShapeBuffer` allocations can be reused for all buffers.