### PR TITLE
Fix typo in fallback font name

### DIFF
--- a/src/font/fallback/unix.rs
+++ b/src/font/fallback/unix.rs
@@ -32,7 +32,7 @@ pub fn forbidden_fallback() -> &'static [&'static str] {
 fn han_unification(locale: &str) -> &'static [&'static str] {
     match locale {
         // Japan
-        "ja" => &["Noto Sans CJK JA"],
+        "ja" => &["Noto Sans CJK JP"],
         // Korea
         "ko" => &["Noto Sans CJK KR"],
         // Hong Kong


### PR DESCRIPTION
 The font name is "Noto Sans CJK JP", not "Noto Sans CJK JA".