### PR TITLE
Fix the character index used for getting a glyph attribute in basic shaping

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -450,12 +450,12 @@ fn shape_skip(
 
     glyphs.extend(
         line[start_run..end_run]
-            .chars()
+            .char_indices()
             .enumerate()
-            .map(|(i, codepoint)| {
+            .map(|(i, (chr_idx, codepoint))| {
                 let glyph_id = charmap.map(codepoint);
                 let x_advance = glyph_metrics.advance_width(glyph_id);
-                let attrs = attrs_list.get_span(i);
+                let attrs = attrs_list.get_span(start_run + chr_idx);
 
                 ShapeGlyph {
                     start: i,


### PR DESCRIPTION
I am using glyphon, based on cosmic-text, to render text in my game, and using basic shaping for most buffers.
After updating, color variations in a buffer stopped working. I found out that a change in #202 was introduced that fetches the attribute data per glyph instead of per run, but it uses a wrong index (index of the code point inside the run instead of buffer text's position). I am unsure how that worked out in their scenario, my guess is that they only used spanned attributes at the beginning of buffers, but I fixed it now.