### PR TITLE
Revert "Fix `Noto Color Emoji` font fallback order for Unix"

### DIFF
--- a/src/font/fallback/unix.rs
+++ b/src/font/fallback/unix.rs
@@ -8,6 +8,8 @@ pub fn common_fallback() -> &'static [&'static str] {
     &[
         /* Sans-serif fallbacks */
         "Noto Sans",
+        /* Emoji fallbacks*/
+        "Noto Color Emoji",
         /* More sans-serif fallbacks */
         "DejaVu Sans",
         "FreeSans",
@@ -18,8 +20,6 @@ pub fn common_fallback() -> &'static [&'static str] {
         /* Symbols fallbacks */
         "Noto Sans Symbols",
         "Noto Sans Symbols2",
-        /* Emoji fallbacks*/
-        "Noto Color Emoji",
         //TODO: Add CJK script here for doublewides?
     ]
 }


### PR DESCRIPTION
This reverts commit 66288ab2da9e5e9e74ede1ed081e581058ab4cca.

Note that putting "Noto Color Emoji" anywhere lower (even just below "DejaVu Sans") creates issue described in https://github.com/pop-os/cosmic-text/issues/327

Putting it above "Noto Sans" breaks text rendering completely.

With the commit reverted I cannot reproduce the original issue https://github.com/pop-os/cosmic-text/pull/68 the commit 66288ab2da9e5e9e74ede1ed081e581058ab4cca was supposed to fix.