### PR TITLE
Avoids panic

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1301,7 +1301,7 @@ impl Buffer {
                 cursor_x_opt = None;
             }
             Motion::BufferEnd => {
-                cursor.line = self.lines.len() - 1;
+                cursor.line = self.lines.len().saturating_sub(1);
                 cursor.index = self.lines.get(cursor.line)?.text().len();
                 cursor_x_opt = None;
             }


### PR DESCRIPTION
I also remember this lint for clippy that can lint against these sorts of arithmatic without checking for overflow
I encountered this when I used this action with no lines of text