### PR TITLE
Apply fallback font to more Unices

### DIFF
--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -9,7 +9,7 @@ use crate::{Font, FontMatchKey, FontSystem, ShapeBuffer};
 
 use self::platform::*;
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows",)))]
+#[cfg(not(any(unix, target_os = "windows")))]
 #[path = "other.rs"]
 mod platform;
 
@@ -17,7 +17,7 @@ mod platform;
 #[path = "macos.rs"]
 mod platform;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, not(any(target_os = "android", target_os = "macos"))))]
 #[path = "unix.rs"]
 mod platform;
 


### PR DESCRIPTION
Stop gatekeeping individual Unices and assume fontconfig (like [fontdb](https://github.com/RazrFalcon/fontdb/blob/62cfd96671eba4debe73eeecf541b1a3a051d223/src/lib.rs#L461)).

Seems to fix weird text shaping on FreeBSD for me with just Iosevka + Noto installed.