### PR TITLE
Add `get_outline_commands_uncached`

### DIFF
--- a/src/swash.rs
+++ b/src/swash.rs
@@ -65,7 +65,7 @@ fn swash_outline_commands(
     font_system: &mut FontSystem,
     context: &mut ScaleContext,
     cache_key: CacheKey,
-) -> Option<Vec<swash::zeno::Command>> {
+) -> Option<Box<[swash::zeno::Command]>> {
     use swash::zeno::PathData as _;
 
     let font = match font_system.get_font(cache_key.font_id) {
@@ -98,7 +98,7 @@ fn swash_outline_commands(
 pub struct SwashCache {
     context: ScaleContext,
     pub image_cache: HashMap<CacheKey, Option<SwashImage>>,
-    pub outline_command_cache: HashMap<CacheKey, Option<Vec<swash::zeno::Command>>>,
+    pub outline_command_cache: HashMap<CacheKey, Option<Box<[swash::zeno::Command]>>>,
 }
 
 impl fmt::Debug for SwashCache {
@@ -137,6 +137,7 @@ impl SwashCache {
             .or_insert_with(|| swash_image(font_system, &mut self.context, cache_key))
     }
 
+    /// Creates outline commands
     pub fn get_outline_commands(
         &mut self,
         font_system: &mut FontSystem,
@@ -146,6 +147,15 @@ impl SwashCache {
             .entry(cache_key)
             .or_insert_with(|| swash_outline_commands(font_system, &mut self.context, cache_key))
             .as_deref()
+    }
+
+    /// Creates outline commands, without caching results
+    pub fn get_outline_commands_uncached(
+        &mut self,
+        font_system: &mut FontSystem,
+        cache_key: CacheKey,
+    ) -> Option<Box<[swash::zeno::Command]>> {
+        swash_outline_commands(font_system, &mut self.context, cache_key)
     }
 
     /// Enumerate pixels in an Image, use `with_image` for better performance


### PR DESCRIPTION
## Intent

Add API to get the outline commands for a glyph without caching results into `outline_command_cache`.

## Context

I am trying to build a font renderer for low powered and memory constrained devices. Since I am caching the results myself (storing the commands on the GPU for on-GPU rendering - e.g. the [Dobbie Method](https://wdobbie.com/)), an uncached version of getting the outline commands allows me to save some memory and avoid a hashmap lookup.

## Extra

I've amended the `outline_command_cache` value type and `swash_outline_commands` return type to `Box<[T]>` to:
- Signal that commands are immutable once created
- Ensure the `Vec` isn't storing any unused capacity (it isn't from my inspection, but, I think it helps enforce that requirement).
- Saves a tiny amount of memory since we no longer need to store the `capacity` value