### PR TITLE
Hint `swash_outline_commands`

### DIFF
--- a/src/swash.rs
+++ b/src/swash.rs
@@ -80,6 +80,7 @@ fn swash_outline_commands(
     let mut scaler = context
         .builder(font.as_swash())
         .size(f32::from_bits(cache_key.font_size_bits))
+        .hint(true)
         .build();
 
     // Scale the outline


### PR DESCRIPTION
Enables hinting when generating outline commands.

### For Source Serif Pro:

#### Without hinting:

![image](https://github.com/user-attachments/assets/dbedd8c0-49db-48cf-82bb-928fb72009d4)

#### With hinting:

![image](https://github.com/user-attachments/assets/d6914c83-9167-4c46-a0dc-9ac278aca8d9)


I'm happy to amend the API to allow it to be passed in, but, we hint `swash_image` by default as shown below. So, I think, in order for the image and outline API to yield more similar output, it makes sense for them to be the same and either hardcode hinting or pass configuration. I think in most cases, IIUC, users will want their fonts hinted.

https://github.com/pop-os/cosmic-text/blob/c8c8aa3fb834155e6431d676a9ad0f009766becb/src/swash.rs#L32