### PR TITLE
Reduce memory usage and loading time of FontSystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ ttf-parser = { version = "0.21", default-features = false }
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.5"
 unicode-segmentation = "1.10.1"
-rayon = { version = "1", optional = true }
 
 [dependencies.swash]
 version = "0.2.0"
@@ -55,7 +54,6 @@ std = [
     "sys-locale",
     "ttf-parser/std",
     "unicode-bidi/std",
-    "rayon"
 ]
 vi = ["modit", "syntect", "cosmic_undo_2"]
 wasm-web = ["sys-locale?/js"]


### PR DESCRIPTION
Related to https://github.com/pop-os/cosmic-applets/issues/723

### Before

- All monospace fonts get cached and `per_script_monospace_font_ids` is calculated even if `monospace_fallback` feature is turned off.
- All monospace fonts get cached in advance. Memory usage is always high because caching reads all data from mmaped files for swash and rustybuzz.
- Calculating `per_script_monospace_font_ids` leads to caching (`get_font` call).

### After

In my testing app:
- Initial loading time is reduced from 700ms to 70ms.
- Memory usage is reduced from 600MB to 100MB.