### PR TITLE
Resolve all lints, update correct MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/cosmic-text/latest/cosmic_text/"
 repository = "https://github.com/pop-os/cosmic-text"
-rust-version = "1.66"
+rust-version = "1.75"
 
 [dependencies]
 bitflags = "2.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/cosmic-text/latest/cosmic_text/"
 repository = "https://github.com/pop-os/cosmic-text"
-rust-version = "1.65"
+rust-version = "1.66"
 
 [dependencies]
 bitflags = "2.4.1"

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -17,7 +17,7 @@ use winit::{
 fn main() {
     env_logger::init();
 
-    let path = env::args().nth(1).unwrap_or(String::new());
+    let path = env::args().nth(1).unwrap_or_default();
 
     let event_loop = EventLoop::new().unwrap();
     let window = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
@@ -71,282 +71,275 @@ fn main() {
         .run(|event, elwt| {
             elwt.set_control_flow(ControlFlow::Wait);
 
+            let Event::WindowEvent { window_id, event } = event else {
+                return;
+            };
+
             match event {
-                Event::WindowEvent { window_id, event } => {
-                    match event {
-                        WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                            log::info!("Updated scale factor for {window_id:?}");
+                WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                    log::info!("Updated scale factor for {window_id:?}");
 
-                            display_scale = scale_factor as f32;
-                            editor.with_buffer_mut(|buffer| {
-                                buffer.set_metrics(font_sizes[font_size_i].scale(display_scale))
-                            });
+                    display_scale = scale_factor as f32;
+                    editor.with_buffer_mut(|buffer| {
+                        buffer.set_metrics(font_sizes[font_size_i].scale(display_scale))
+                    });
 
-                            window.request_redraw();
-                        }
-                        WindowEvent::RedrawRequested => {
-                            let (width, height) = {
-                                let size = window.inner_size();
-                                (size.width, size.height)
-                            };
+                    window.request_redraw();
+                }
+                WindowEvent::RedrawRequested => {
+                    let (width, height) = {
+                        let size = window.inner_size();
+                        (size.width, size.height)
+                    };
 
-                            surface
-                                .resize(
-                                    NonZeroU32::new(width).unwrap(),
-                                    NonZeroU32::new(height).unwrap(),
-                                )
-                                .unwrap();
+                    surface
+                        .resize(
+                            NonZeroU32::new(width).unwrap(),
+                            NonZeroU32::new(height).unwrap(),
+                        )
+                        .unwrap();
 
-                            let mut surface_buffer = surface.buffer_mut().unwrap();
-                            let surface_buffer_u8 = unsafe {
-                                slice::from_raw_parts_mut(
-                                    surface_buffer.as_mut_ptr() as *mut u8,
-                                    surface_buffer.len() * 4,
-                                )
-                            };
-                            let mut pixmap =
-                                PixmapMut::from_bytes(surface_buffer_u8, width, height).unwrap();
-                            pixmap.fill(tiny_skia::Color::from_rgba8(0, 0, 0, 0xFF));
+                    let mut surface_buffer = surface.buffer_mut().unwrap();
+                    let surface_buffer_u8 = unsafe {
+                        slice::from_raw_parts_mut(
+                            surface_buffer.as_mut_ptr() as *mut u8,
+                            surface_buffer.len() * 4,
+                        )
+                    };
+                    let mut pixmap =
+                        PixmapMut::from_bytes(surface_buffer_u8, width, height).unwrap();
+                    pixmap.fill(tiny_skia::Color::from_rgba8(0, 0, 0, 0xFF));
 
-                            editor.with_buffer_mut(|buffer| {
-                                buffer.set_size(
-                                    Some(width as f32 - scrollbar_width * display_scale),
-                                    Some(height as f32),
-                                )
-                            });
+                    editor.with_buffer_mut(|buffer| {
+                        buffer.set_size(
+                            Some(width as f32 - scrollbar_width * display_scale),
+                            Some(height as f32),
+                        )
+                    });
 
-                            let mut paint = Paint::default();
-                            paint.anti_alias = false;
-                            editor.shape_as_needed(true);
-                            editor.draw(&mut swash_cache, |x, y, w, h, color| {
-                                // Note: due to softbuffer and tiny_skia having incompatible internal color representations we swap
-                                // the red and blue channels here
-                                paint.set_color_rgba8(color.b(), color.g(), color.r(), color.a());
-                                pixmap.fill_rect(
-                                    Rect::from_xywh(x as f32, y as f32, w as f32, h as f32)
-                                        .unwrap(),
-                                    &paint,
-                                    Transform::identity(),
-                                    None,
-                                );
-                            });
-                            if let Some((x, y)) = editor.cursor_position() {
-                                window.set_ime_cursor_area(
-                                    PhysicalPosition::new(x, y),
-                                    PhysicalSize::new(20, 20),
-                                );
-                            }
-
-                            // Draw scrollbar
-                            {
-                                let mut start_line_opt = None;
-                                let mut end_line = 0;
-                                editor.with_buffer(|buffer| {
-                                    for run in buffer.layout_runs() {
-                                        end_line = run.line_i;
-                                        if start_line_opt.is_none() {
-                                            start_line_opt = Some(end_line);
-                                        }
-                                    }
-                                });
-
-                                let start_line = start_line_opt.unwrap_or(end_line);
-                                let lines = editor.with_buffer(|buffer| buffer.lines.len());
-                                let start_y = (start_line * height as usize) / lines;
-                                let end_y = (end_line * height as usize) / lines;
-                                paint.set_color_rgba8(0xFF, 0xFF, 0xFF, 0x40);
-                                if end_y > start_y {
-                                    pixmap.fill_rect(
-                                        Rect::from_xywh(
-                                            width as f32 - scrollbar_width * display_scale,
-                                            start_y as f32,
-                                            scrollbar_width * display_scale,
-                                            (end_y - start_y) as f32,
-                                        )
-                                        .unwrap(),
-                                        &paint,
-                                        Transform::identity(),
-                                        None,
-                                    );
-                                }
-                            }
-
-                            surface_buffer.present().unwrap();
-                        }
-                        WindowEvent::ModifiersChanged(modifiers) => {
-                            ctrl_pressed = modifiers.state().control_key()
-                        }
-                        WindowEvent::KeyboardInput { event, .. } => {
-                            let KeyEvent {
-                                logical_key, state, ..
-                            } = event;
-
-                            if state.is_pressed() {
-                                match logical_key {
-                                    Key::Named(NamedKey::ArrowLeft) => {
-                                        editor.action(Action::Motion(Motion::Left))
-                                    }
-                                    Key::Named(NamedKey::ArrowRight) => {
-                                        editor.action(Action::Motion(Motion::Right))
-                                    }
-                                    Key::Named(NamedKey::ArrowUp) => {
-                                        editor.action(Action::Motion(Motion::Up))
-                                    }
-                                    Key::Named(NamedKey::ArrowDown) => {
-                                        editor.action(Action::Motion(Motion::Down))
-                                    }
-                                    Key::Named(NamedKey::Home) => {
-                                        editor.action(Action::Motion(Motion::Home))
-                                    }
-                                    Key::Named(NamedKey::End) => {
-                                        editor.action(Action::Motion(Motion::End))
-                                    }
-                                    Key::Named(NamedKey::PageUp) => {
-                                        editor.action(Action::Motion(Motion::PageUp))
-                                    }
-                                    Key::Named(NamedKey::PageDown) => {
-                                        editor.action(Action::Motion(Motion::PageDown))
-                                    }
-                                    Key::Named(NamedKey::Escape) => editor.action(Action::Escape),
-                                    Key::Named(NamedKey::Enter) => editor.action(Action::Enter),
-                                    Key::Named(NamedKey::Backspace) => {
-                                        editor.action(Action::Backspace)
-                                    }
-                                    Key::Named(NamedKey::Delete) => editor.action(Action::Delete),
-                                    Key::Named(key) => {
-                                        if let Some(text) = key.to_text() {
-                                            for c in text.chars() {
-                                                editor.action(Action::Insert(c));
-                                            }
-                                        }
-                                    }
-                                    Key::Character(text) => {
-                                        if ctrl_pressed {
-                                            match &*text {
-                                                "0" => {
-                                                    font_size_i = font_size_default;
-                                                    editor.with_buffer_mut(|buffer| {
-                                                        buffer.set_metrics(
-                                                            font_sizes[font_size_i]
-                                                                .scale(display_scale),
-                                                        )
-                                                    });
-                                                }
-                                                "-" => {
-                                                    if font_size_i > 0 {
-                                                        font_size_i -= 1;
-                                                        editor.with_buffer_mut(|buffer| {
-                                                            buffer.set_metrics(
-                                                                font_sizes[font_size_i]
-                                                                    .scale(display_scale),
-                                                            )
-                                                        });
-                                                    }
-                                                }
-                                                "=" => {
-                                                    if font_size_i + 1 < font_sizes.len() {
-                                                        font_size_i += 1;
-                                                        editor.with_buffer_mut(|buffer| {
-                                                            buffer.set_metrics(
-                                                                font_sizes[font_size_i]
-                                                                    .scale(display_scale),
-                                                            )
-                                                        });
-                                                    }
-                                                }
-                                                "s" => {
-                                                    let mut text = String::new();
-                                                    editor.with_buffer(|buffer| {
-                                                        for line in buffer.lines.iter() {
-                                                            text.push_str(line.text());
-                                                            text.push_str(line.ending().as_str());
-                                                        }
-                                                    });
-                                                    fs::write(&path, &text).unwrap();
-                                                    log::info!("saved {:?}", path);
-                                                }
-                                                _ => {}
-                                            }
-                                        } else {
-                                            for c in text.chars() {
-                                                editor.action(Action::Insert(c));
-                                            }
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                                window.request_redraw();
-                            }
-                        }
-                        WindowEvent::CursorMoved {
-                            device_id: _,
-                            position,
-                        } => {
-                            // Update saved mouse position for use when handling click events
-                            mouse_x = position.x;
-                            mouse_y = position.y;
-
-                            // Implement dragging
-                            if mouse_left.is_pressed() {
-                                // Execute Drag editor action (update selection)
-                                editor.action(Action::Drag {
-                                    x: position.x as i32,
-                                    y: position.y as i32,
-                                });
-
-                                // Scroll if cursor is near edge of window while dragging
-                                if mouse_y <= 5.0 {
-                                    editor.action(Action::Scroll { lines: -1 });
-                                } else if mouse_y - 5.0 >= window.inner_size().height as f64 {
-                                    editor.action(Action::Scroll { lines: 1 });
-                                }
-
-                                window.request_redraw();
-                            }
-                        }
-                        WindowEvent::MouseInput {
-                            device_id: _,
-                            state,
-                            button,
-                        } => {
-                            if button == MouseButton::Left {
-                                if state == ElementState::Pressed
-                                    && mouse_left == ElementState::Released
-                                {
-                                    editor.action(Action::Click {
-                                        x: mouse_x as i32,
-                                        y: mouse_y as i32,
-                                    });
-                                    window.request_redraw();
-                                }
-                                mouse_left = state;
-                            }
-                        }
-                        WindowEvent::MouseWheel {
-                            device_id: _,
-                            delta,
-                            phase: _,
-                        } => {
-                            let line_delta = match delta {
-                                MouseScrollDelta::LineDelta(_x, y) => y as i32,
-                                MouseScrollDelta::PixelDelta(PhysicalPosition { x: _, y }) => {
-                                    unapplied_scroll_delta += y;
-                                    let line_delta = (unapplied_scroll_delta / 20.0).floor();
-                                    unapplied_scroll_delta -= line_delta * 20.0;
-                                    line_delta as i32
-                                }
-                            };
-                            if line_delta != 0 {
-                                editor.action(Action::Scroll { lines: -line_delta });
-                            }
-                            window.request_redraw();
-                        }
-                        WindowEvent::CloseRequested => {
-                            //TODO: just close one window
-                            elwt.exit();
-                        }
-                        _ => {}
+                    let mut paint = Paint {
+                        anti_alias: false,
+                        ..Default::default()
+                    };
+                    editor.shape_as_needed(true);
+                    editor.draw(&mut swash_cache, |x, y, w, h, color| {
+                        // Note: due to softbuffer and tiny_skia having incompatible internal color representations we swap
+                        // the red and blue channels here
+                        paint.set_color_rgba8(color.b(), color.g(), color.r(), color.a());
+                        pixmap.fill_rect(
+                            Rect::from_xywh(x as f32, y as f32, w as f32, h as f32).unwrap(),
+                            &paint,
+                            Transform::identity(),
+                            None,
+                        );
+                    });
+                    if let Some((x, y)) = editor.cursor_position() {
+                        window.set_ime_cursor_area(
+                            PhysicalPosition::new(x, y),
+                            PhysicalSize::new(20, 20),
+                        );
                     }
+
+                    // Draw scrollbar
+                    {
+                        let mut start_line_opt = None;
+                        let mut end_line = 0;
+                        editor.with_buffer(|buffer| {
+                            for run in buffer.layout_runs() {
+                                end_line = run.line_i;
+                                if start_line_opt.is_none() {
+                                    start_line_opt = Some(end_line);
+                                }
+                            }
+                        });
+
+                        let start_line = start_line_opt.unwrap_or(end_line);
+                        let lines = editor.with_buffer(|buffer| buffer.lines.len());
+                        let start_y = (start_line * height as usize) / lines;
+                        let end_y = (end_line * height as usize) / lines;
+                        paint.set_color_rgba8(0xFF, 0xFF, 0xFF, 0x40);
+                        if end_y > start_y {
+                            pixmap.fill_rect(
+                                Rect::from_xywh(
+                                    width as f32 - scrollbar_width * display_scale,
+                                    start_y as f32,
+                                    scrollbar_width * display_scale,
+                                    (end_y - start_y) as f32,
+                                )
+                                .unwrap(),
+                                &paint,
+                                Transform::identity(),
+                                None,
+                            );
+                        }
+                    }
+
+                    surface_buffer.present().unwrap();
+                }
+                WindowEvent::ModifiersChanged(modifiers) => {
+                    ctrl_pressed = modifiers.state().control_key()
+                }
+                WindowEvent::KeyboardInput { event, .. } => {
+                    let KeyEvent {
+                        logical_key, state, ..
+                    } = event;
+
+                    if state.is_pressed() {
+                        match logical_key {
+                            Key::Named(NamedKey::ArrowLeft) => {
+                                editor.action(Action::Motion(Motion::Left))
+                            }
+                            Key::Named(NamedKey::ArrowRight) => {
+                                editor.action(Action::Motion(Motion::Right))
+                            }
+                            Key::Named(NamedKey::ArrowUp) => {
+                                editor.action(Action::Motion(Motion::Up))
+                            }
+                            Key::Named(NamedKey::ArrowDown) => {
+                                editor.action(Action::Motion(Motion::Down))
+                            }
+                            Key::Named(NamedKey::Home) => {
+                                editor.action(Action::Motion(Motion::Home))
+                            }
+                            Key::Named(NamedKey::End) => editor.action(Action::Motion(Motion::End)),
+                            Key::Named(NamedKey::PageUp) => {
+                                editor.action(Action::Motion(Motion::PageUp))
+                            }
+                            Key::Named(NamedKey::PageDown) => {
+                                editor.action(Action::Motion(Motion::PageDown))
+                            }
+                            Key::Named(NamedKey::Escape) => editor.action(Action::Escape),
+                            Key::Named(NamedKey::Enter) => editor.action(Action::Enter),
+                            Key::Named(NamedKey::Backspace) => editor.action(Action::Backspace),
+                            Key::Named(NamedKey::Delete) => editor.action(Action::Delete),
+                            Key::Named(key) => {
+                                if let Some(text) = key.to_text() {
+                                    for c in text.chars() {
+                                        editor.action(Action::Insert(c));
+                                    }
+                                }
+                            }
+                            Key::Character(text) => {
+                                if ctrl_pressed {
+                                    match &*text {
+                                        "0" => {
+                                            font_size_i = font_size_default;
+                                            editor.with_buffer_mut(|buffer| {
+                                                buffer.set_metrics(
+                                                    font_sizes[font_size_i].scale(display_scale),
+                                                )
+                                            });
+                                        }
+                                        "-" => {
+                                            if font_size_i > 0 {
+                                                font_size_i -= 1;
+                                                editor.with_buffer_mut(|buffer| {
+                                                    buffer.set_metrics(
+                                                        font_sizes[font_size_i]
+                                                            .scale(display_scale),
+                                                    )
+                                                });
+                                            }
+                                        }
+                                        "=" => {
+                                            if font_size_i + 1 < font_sizes.len() {
+                                                font_size_i += 1;
+                                                editor.with_buffer_mut(|buffer| {
+                                                    buffer.set_metrics(
+                                                        font_sizes[font_size_i]
+                                                            .scale(display_scale),
+                                                    )
+                                                });
+                                            }
+                                        }
+                                        "s" => {
+                                            let mut text = String::new();
+                                            editor.with_buffer(|buffer| {
+                                                for line in buffer.lines.iter() {
+                                                    text.push_str(line.text());
+                                                    text.push_str(line.ending().as_str());
+                                                }
+                                            });
+                                            fs::write(&path, &text).unwrap();
+                                            log::info!("saved {:?}", path);
+                                        }
+                                        _ => {}
+                                    }
+                                } else {
+                                    for c in text.chars() {
+                                        editor.action(Action::Insert(c));
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                        window.request_redraw();
+                    }
+                }
+                WindowEvent::CursorMoved {
+                    device_id: _,
+                    position,
+                } => {
+                    // Update saved mouse position for use when handling click events
+                    mouse_x = position.x;
+                    mouse_y = position.y;
+
+                    // Implement dragging
+                    if mouse_left.is_pressed() {
+                        // Execute Drag editor action (update selection)
+                        editor.action(Action::Drag {
+                            x: position.x as i32,
+                            y: position.y as i32,
+                        });
+
+                        // Scroll if cursor is near edge of window while dragging
+                        if mouse_y <= 5.0 {
+                            editor.action(Action::Scroll { lines: -1 });
+                        } else if mouse_y - 5.0 >= window.inner_size().height as f64 {
+                            editor.action(Action::Scroll { lines: 1 });
+                        }
+
+                        window.request_redraw();
+                    }
+                }
+                WindowEvent::MouseInput {
+                    device_id: _,
+                    state,
+                    button,
+                } => {
+                    if button == MouseButton::Left {
+                        if state == ElementState::Pressed && mouse_left == ElementState::Released {
+                            editor.action(Action::Click {
+                                x: mouse_x as i32,
+                                y: mouse_y as i32,
+                            });
+                            window.request_redraw();
+                        }
+                        mouse_left = state;
+                    }
+                }
+                WindowEvent::MouseWheel {
+                    device_id: _,
+                    delta,
+                    phase: _,
+                } => {
+                    let line_delta = match delta {
+                        MouseScrollDelta::LineDelta(_x, y) => y as i32,
+                        MouseScrollDelta::PixelDelta(PhysicalPosition { x: _, y }) => {
+                            unapplied_scroll_delta += y;
+                            let line_delta = (unapplied_scroll_delta / 20.0).floor();
+                            unapplied_scroll_delta -= line_delta * 20.0;
+                            line_delta as i32
+                        }
+                    };
+                    if line_delta != 0 {
+                        editor.action(Action::Scroll { lines: -line_delta });
+                    }
+                    window.request_redraw();
+                }
+                WindowEvent::CloseRequested => {
+                    //TODO: just close one window
+                    elwt.exit();
                 }
                 _ => {}
             }

--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -19,7 +19,7 @@ use winit::{
     window::WindowBuilder,
 };
 
-fn set_buffer_text<'a>(buffer: &mut BorrowedWithFontSystem<'a, Buffer>) {
+fn set_buffer_text(buffer: &mut BorrowedWithFontSystem<'_, Buffer>) {
     let attrs = Attrs::new();
     let serif_attrs = attrs.family(Family::Serif);
     let mono_attrs = attrs.family(Family::Monospace);
@@ -126,7 +126,7 @@ fn main() {
             Some(window.inner_size().height as f32),
         )
     });
-    editor.with_buffer_mut(|buffer| set_buffer_text(buffer));
+    editor.with_buffer_mut(set_buffer_text);
 
     let mut ctrl_pressed = false;
     let mut mouse_x = 0.0;
@@ -144,206 +144,194 @@ fn main() {
         .run(|event, elwt| {
             elwt.set_control_flow(ControlFlow::Wait);
 
+            let Event::WindowEvent { window_id, event } = event else {
+                return;
+            };
+
             match event {
-                Event::WindowEvent { window_id, event } => {
-                    match event {
-                        WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                            log::info!("Updated scale factor for {window_id:?}");
+                WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                    log::info!("Updated scale factor for {window_id:?}");
 
-                            display_scale = scale_factor as f32;
-                            editor.with_buffer_mut(|buffer| {
-                                buffer.set_metrics(metrics.scale(display_scale))
-                            });
+                    display_scale = scale_factor as f32;
+                    editor
+                        .with_buffer_mut(|buffer| buffer.set_metrics(metrics.scale(display_scale)));
 
-                            window.request_redraw();
-                        }
-                        WindowEvent::RedrawRequested => {
-                            let (width, height) = {
-                                let size = window.inner_size();
-                                (size.width, size.height)
-                            };
+                    window.request_redraw();
+                }
+                WindowEvent::RedrawRequested => {
+                    let (width, height) = {
+                        let size = window.inner_size();
+                        (size.width, size.height)
+                    };
 
-                            surface
-                                .resize(
-                                    NonZeroU32::new(width).unwrap(),
-                                    NonZeroU32::new(height).unwrap(),
-                                )
-                                .unwrap();
+                    surface
+                        .resize(
+                            NonZeroU32::new(width).unwrap(),
+                            NonZeroU32::new(height).unwrap(),
+                        )
+                        .unwrap();
 
-                            let mut surface_buffer = surface.buffer_mut().unwrap();
-                            let surface_buffer_u8 = unsafe {
-                                slice::from_raw_parts_mut(
-                                    surface_buffer.as_mut_ptr() as *mut u8,
-                                    surface_buffer.len() * 4,
-                                )
-                            };
-                            let mut pixmap =
-                                PixmapMut::from_bytes(surface_buffer_u8, width, height).unwrap();
-                            pixmap.fill(bg_color);
+                    let mut surface_buffer = surface.buffer_mut().unwrap();
+                    let surface_buffer_u8 = unsafe {
+                        slice::from_raw_parts_mut(
+                            surface_buffer.as_mut_ptr() as *mut u8,
+                            surface_buffer.len() * 4,
+                        )
+                    };
+                    let mut pixmap =
+                        PixmapMut::from_bytes(surface_buffer_u8, width, height).unwrap();
+                    pixmap.fill(bg_color);
 
-                            editor.with_buffer_mut(|buffer| {
-                                buffer.set_size(Some(width as f32), Some(height as f32))
-                            });
+                    editor.with_buffer_mut(|buffer| {
+                        buffer.set_size(Some(width as f32), Some(height as f32))
+                    });
 
-                            let mut paint = Paint::default();
-                            paint.anti_alias = false;
-                            editor.shape_as_needed(true);
+                    let mut paint = Paint {
+                        anti_alias: false,
+                        ..Default::default()
+                    };
+                    editor.shape_as_needed(true);
 
-                            editor.draw(
-                                &mut swash_cache,
-                                font_color,
-                                cursor_color,
-                                selection_color,
-                                selected_text_color,
-                                |x, y, w, h, color| {
-                                    // Note: due to softbuffer and tiny_skia having incompatible internal color representations we swap
-                                    // the red and blue channels here
-                                    paint.set_color_rgba8(
-                                        color.b(),
-                                        color.g(),
-                                        color.r(),
-                                        color.a(),
-                                    );
-                                    pixmap.fill_rect(
-                                        Rect::from_xywh(x as f32, y as f32, w as f32, h as f32)
-                                            .unwrap(),
-                                        &paint,
-                                        Transform::identity(),
-                                        None,
-                                    );
-                                },
+                    editor.draw(
+                        &mut swash_cache,
+                        font_color,
+                        cursor_color,
+                        selection_color,
+                        selected_text_color,
+                        |x, y, w, h, color| {
+                            // Note: due to softbuffer and tiny_skia having incompatible internal color representations we swap
+                            // the red and blue channels here
+                            paint.set_color_rgba8(color.b(), color.g(), color.r(), color.a());
+                            pixmap.fill_rect(
+                                Rect::from_xywh(x as f32, y as f32, w as f32, h as f32).unwrap(),
+                                &paint,
+                                Transform::identity(),
+                                None,
                             );
+                        },
+                    );
 
-                            surface_buffer.present().unwrap();
-                        }
-                        WindowEvent::ModifiersChanged(modifiers) => {
-                            ctrl_pressed = modifiers.state().control_key()
-                        }
-                        WindowEvent::KeyboardInput { event, .. } => {
-                            let KeyEvent {
-                                logical_key, state, ..
-                            } = event;
+                    surface_buffer.present().unwrap();
+                }
+                WindowEvent::ModifiersChanged(modifiers) => {
+                    ctrl_pressed = modifiers.state().control_key()
+                }
+                WindowEvent::KeyboardInput { event, .. } => {
+                    let KeyEvent {
+                        logical_key, state, ..
+                    } = event;
 
-                            if state.is_pressed() {
-                                match logical_key {
-                                    Key::Named(NamedKey::ArrowLeft) => {
-                                        editor.action(Action::Motion(Motion::Left))
-                                    }
-                                    Key::Named(NamedKey::ArrowRight) => {
-                                        editor.action(Action::Motion(Motion::Right))
-                                    }
-                                    Key::Named(NamedKey::ArrowUp) => {
-                                        editor.action(Action::Motion(Motion::Up))
-                                    }
-                                    Key::Named(NamedKey::ArrowDown) => {
-                                        editor.action(Action::Motion(Motion::Down))
-                                    }
-                                    Key::Named(NamedKey::Home) => {
-                                        editor.action(Action::Motion(Motion::Home))
-                                    }
-                                    Key::Named(NamedKey::End) => {
-                                        editor.action(Action::Motion(Motion::End))
-                                    }
-                                    Key::Named(NamedKey::PageUp) => {
-                                        editor.action(Action::Motion(Motion::PageUp))
-                                    }
-                                    Key::Named(NamedKey::PageDown) => {
-                                        editor.action(Action::Motion(Motion::PageDown))
-                                    }
-                                    Key::Named(NamedKey::Escape) => editor.action(Action::Escape),
-                                    Key::Named(NamedKey::Enter) => editor.action(Action::Enter),
-                                    Key::Named(NamedKey::Backspace) => {
-                                        editor.action(Action::Backspace)
-                                    }
-                                    Key::Named(NamedKey::Delete) => editor.action(Action::Delete),
-                                    Key::Named(key) => {
-                                        if let Some(text) = key.to_text() {
-                                            for c in text.chars() {
-                                                editor.action(Action::Insert(c));
-                                            }
-                                        }
-                                    }
-                                    Key::Character(text) => {
-                                        if !ctrl_pressed {
-                                            for c in text.chars() {
-                                                editor.action(Action::Insert(c));
-                                            }
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                                window.request_redraw();
+                    if state.is_pressed() {
+                        match logical_key {
+                            Key::Named(NamedKey::ArrowLeft) => {
+                                editor.action(Action::Motion(Motion::Left))
                             }
-                        }
-                        WindowEvent::CursorMoved {
-                            device_id: _,
-                            position,
-                        } => {
-                            // Update saved mouse position for use when handling click events
-                            mouse_x = position.x;
-                            mouse_y = position.y;
-
-                            // Implement dragging
-                            if mouse_left.is_pressed() {
-                                // Execute Drag editor action (update selection)
-                                editor.action(Action::Drag {
-                                    x: position.x as i32,
-                                    y: position.y as i32,
-                                });
-
-                                // Scroll if cursor is near edge of window while dragging
-                                if mouse_y <= 5.0 {
-                                    editor.action(Action::Scroll { lines: -1 });
-                                } else if mouse_y - 5.0 >= window.inner_size().height as f64 {
-                                    editor.action(Action::Scroll { lines: 1 });
-                                }
-
-                                window.request_redraw();
+                            Key::Named(NamedKey::ArrowRight) => {
+                                editor.action(Action::Motion(Motion::Right))
                             }
-                        }
-                        WindowEvent::MouseInput {
-                            device_id: _,
-                            state,
-                            button,
-                        } => {
-                            if button == MouseButton::Left {
-                                if state == ElementState::Pressed
-                                    && mouse_left == ElementState::Released
-                                {
-                                    editor.action(Action::Click {
-                                        x: mouse_x /*- line_x*/ as i32,
-                                        y: mouse_y as i32,
-                                    });
-                                    window.request_redraw();
-                                }
-                                mouse_left = state;
+                            Key::Named(NamedKey::ArrowUp) => {
+                                editor.action(Action::Motion(Motion::Up))
                             }
-                        }
-                        WindowEvent::MouseWheel {
-                            device_id: _,
-                            delta,
-                            phase: _,
-                        } => {
-                            let line_delta = match delta {
-                                MouseScrollDelta::LineDelta(_x, y) => y as i32,
-                                MouseScrollDelta::PixelDelta(PhysicalPosition { x: _, y }) => {
-                                    unapplied_scroll_delta += y;
-                                    let line_delta = (unapplied_scroll_delta / 20.0).floor();
-                                    unapplied_scroll_delta -= line_delta * 20.0;
-                                    line_delta as i32
-                                }
-                            };
-                            if line_delta != 0 {
-                                editor.action(Action::Scroll { lines: -line_delta });
+                            Key::Named(NamedKey::ArrowDown) => {
+                                editor.action(Action::Motion(Motion::Down))
                             }
+                            Key::Named(NamedKey::Home) => {
+                                editor.action(Action::Motion(Motion::Home))
+                            }
+                            Key::Named(NamedKey::End) => editor.action(Action::Motion(Motion::End)),
+                            Key::Named(NamedKey::PageUp) => {
+                                editor.action(Action::Motion(Motion::PageUp))
+                            }
+                            Key::Named(NamedKey::PageDown) => {
+                                editor.action(Action::Motion(Motion::PageDown))
+                            }
+                            Key::Named(NamedKey::Escape) => editor.action(Action::Escape),
+                            Key::Named(NamedKey::Enter) => editor.action(Action::Enter),
+                            Key::Named(NamedKey::Backspace) => editor.action(Action::Backspace),
+                            Key::Named(NamedKey::Delete) => editor.action(Action::Delete),
+                            Key::Named(key) => {
+                                if let Some(text) = key.to_text() {
+                                    for c in text.chars() {
+                                        editor.action(Action::Insert(c));
+                                    }
+                                }
+                            }
+                            Key::Character(text) => {
+                                if !ctrl_pressed {
+                                    for c in text.chars() {
+                                        editor.action(Action::Insert(c));
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                        window.request_redraw();
+                    }
+                }
+                WindowEvent::CursorMoved {
+                    device_id: _,
+                    position,
+                } => {
+                    // Update saved mouse position for use when handling click events
+                    mouse_x = position.x;
+                    mouse_y = position.y;
+
+                    // Implement dragging
+                    if mouse_left.is_pressed() {
+                        // Execute Drag editor action (update selection)
+                        editor.action(Action::Drag {
+                            x: position.x as i32,
+                            y: position.y as i32,
+                        });
+
+                        // Scroll if cursor is near edge of window while dragging
+                        if mouse_y <= 5.0 {
+                            editor.action(Action::Scroll { lines: -1 });
+                        } else if mouse_y - 5.0 >= window.inner_size().height as f64 {
+                            editor.action(Action::Scroll { lines: 1 });
+                        }
+
+                        window.request_redraw();
+                    }
+                }
+                WindowEvent::MouseInput {
+                    device_id: _,
+                    state,
+                    button,
+                } => {
+                    if button == MouseButton::Left {
+                        if state == ElementState::Pressed && mouse_left == ElementState::Released {
+                            editor.action(Action::Click {
+                                x: mouse_x /*- line_x*/ as i32,
+                                y: mouse_y as i32,
+                            });
                             window.request_redraw();
                         }
-                        WindowEvent::CloseRequested => {
-                            //TODO: just close one window
-                            elwt.exit();
-                        }
-                        _ => {}
+                        mouse_left = state;
                     }
+                }
+                WindowEvent::MouseWheel {
+                    device_id: _,
+                    delta,
+                    phase: _,
+                } => {
+                    let line_delta = match delta {
+                        MouseScrollDelta::LineDelta(_x, y) => y as i32,
+                        MouseScrollDelta::PixelDelta(PhysicalPosition { x: _, y }) => {
+                            unapplied_scroll_delta += y;
+                            let line_delta = (unapplied_scroll_delta / 20.0).floor();
+                            unapplied_scroll_delta -= line_delta * 20.0;
+                            line_delta as i32
+                        }
+                    };
+                    if line_delta != 0 {
+                        editor.action(Action::Scroll { lines: -line_delta });
+                    }
+                    window.request_redraw();
+                }
+                WindowEvent::CloseRequested => {
+                    //TODO: just close one window
+                    elwt.exit();
                 }
                 _ => {}
             }

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -340,6 +340,7 @@ impl AttrsList {
     }
 
     /// Split attributes list at an offset
+    #[allow(clippy::missing_panics_doc)]
     pub fn split_off(&mut self, index: usize) -> Self {
         let mut new = Self::new(self.defaults.as_attrs());
         let mut removes = Vec::new();

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -203,6 +203,7 @@ impl BufferLine {
     }
 
     /// Shape line, will cache results
+    #[allow(clippy::missing_panics_doc)]
     pub fn shape(&mut self, font_system: &mut FontSystem, tab_width: u16) -> &ShapeLine {
         if self.shape_opt.is_unused() {
             let mut line = self
@@ -228,6 +229,7 @@ impl BufferLine {
     }
 
     /// Layout line, will cache results
+    #[allow(clippy::missing_panics_doc)]
     pub fn layout(
         &mut self,
         font_system: &mut FontSystem,

--- a/src/cached.rs
+++ b/src/cached.rs
@@ -67,6 +67,7 @@ impl<T: Clone + Debug> Cached<T> {
     }
 
     /// Moves the value from `Self::Used` to `Self::Unused`.
+    #[allow(clippy::missing_panics_doc)]
     pub fn set_unused(&mut self) {
         if matches!(*self, Self::Used(_)) {
             *self = Self::Unused(self.take_used().expect("cached value should be used"));

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -87,9 +87,9 @@ impl LayoutCursor {
 pub enum Motion {
     /// Apply specific [`LayoutCursor`]
     LayoutCursor(LayoutCursor),
-    /// Move cursor to previous character ([Self::Left] in LTR, [Self::Right] in RTL)
+    /// Move cursor to previous character ([`Self::Left`] in LTR, [`Self::Right`] in RTL)
     Previous,
-    /// Move cursor to next character ([Self::Right] in LTR, [Self::Left] in RTL)
+    /// Move cursor to next character ([`Self::Right`] in LTR, [`Self::Left`] in RTL)
     Next,
     /// Move cursor left
     Left,

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -109,6 +109,7 @@ impl<'buffer> Editor<'buffer> {
 
     /// Draw the editor
     #[cfg(feature = "swash")]
+    #[allow(clippy::too_many_arguments)]
     pub fn draw<F>(
         &self,
         font_system: &mut FontSystem,
@@ -527,16 +528,13 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
 
     fn apply_change(&mut self, change: &Change) -> bool {
         // Cannot apply changes if there is a pending change
-        match self.change.take() {
-            Some(pending) => {
-                if !pending.items.is_empty() {
-                    //TODO: is this a good idea?
-                    log::warn!("pending change caused apply_change to be ignored!");
-                    self.change = Some(pending);
-                    return false;
-                }
+        if let Some(pending) = self.change.take() {
+            if !pending.items.is_empty() {
+                //TODO: is this a good idea?
+                log::warn!("pending change caused apply_change to be ignored!");
+                self.change = Some(pending);
+                return false;
             }
-            None => {}
         }
 
         for item in change.items.iter() {
@@ -898,7 +896,7 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
     }
 }
 
-impl<'font_system, 'buffer> BorrowedWithFontSystem<'font_system, Editor<'buffer>> {
+impl BorrowedWithFontSystem<'_, Editor<'_>> {
     #[cfg(feature = "swash")]
     pub fn draw<F>(
         &mut self,

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -71,7 +71,7 @@ pub enum BufferRef<'buffer> {
     Arc(Arc<Buffer>),
 }
 
-impl<'buffer> Clone for BufferRef<'buffer> {
+impl Clone for BufferRef<'_> {
     fn clone(&self) -> Self {
         match self {
             Self::Owned(buffer) => Self::Owned(buffer.clone()),
@@ -81,7 +81,7 @@ impl<'buffer> Clone for BufferRef<'buffer> {
     }
 }
 
-impl<'buffer> From<Buffer> for BufferRef<'buffer> {
+impl From<Buffer> for BufferRef<'_> {
     fn from(buffer: Buffer) -> Self {
         Self::Owned(buffer)
     }
@@ -93,7 +93,7 @@ impl<'buffer> From<&'buffer mut Buffer> for BufferRef<'buffer> {
     }
 }
 
-impl<'buffer> From<Arc<Buffer>> for BufferRef<'buffer> {
+impl From<Arc<Buffer>> for BufferRef<'_> {
     fn from(arc: Arc<Buffer>) -> Self {
         Self::Arc(arc)
     }
@@ -197,7 +197,7 @@ pub trait Edit<'buffer> {
 
     /// Set the [`Buffer`] redraw flag
     fn set_redraw(&mut self, redraw: bool) {
-        self.with_buffer_mut(|buffer| buffer.set_redraw(redraw))
+        self.with_buffer_mut(|buffer| buffer.set_redraw(redraw));
     }
 
     /// Get the current cursor
@@ -300,7 +300,7 @@ pub trait Edit<'buffer> {
     /// Delete text starting at start Cursor and ending at end Cursor
     fn delete_range(&mut self, start: Cursor, end: Cursor);
 
-    /// Insert text at specified cursor with specified attrs_list
+    /// Insert text at specified cursor with specified `attrs_list`
     fn insert_at(&mut self, cursor: Cursor, data: &str, attrs_list: Option<AttrsList>) -> Cursor;
 
     /// Copy selection
@@ -334,7 +334,7 @@ pub trait Edit<'buffer> {
     fn cursor_position(&self) -> Option<(i32, i32)>;
 }
 
-impl<'font_system, 'buffer, E: Edit<'buffer>> BorrowedWithFontSystem<'font_system, E> {
+impl<'buffer, E: Edit<'buffer>> BorrowedWithFontSystem<'_, E> {
     /// Get the internal [`Buffer`], mutably
     pub fn with_buffer_mut<F: FnOnce(&mut BorrowedWithFontSystem<Buffer>) -> T, T>(
         &mut self,

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -125,7 +125,7 @@ impl<'syntax_system, 'buffer> SyntaxEditor<'syntax_system, 'buffer> {
 
         let text = fs::read_to_string(path)?;
         self.editor.with_buffer_mut(|buffer| {
-            buffer.set_text(font_system, &text, attrs, Shaping::Advanced)
+            buffer.set_text(font_system, &text, attrs, Shaping::Advanced);
         });
 
         //TODO: re-use text
@@ -235,7 +235,7 @@ impl<'syntax_system, 'buffer> SyntaxEditor<'syntax_system, 'buffer> {
     }
 }
 
-impl<'syntax_system, 'buffer> Edit<'buffer> for SyntaxEditor<'syntax_system, 'buffer> {
+impl<'buffer> Edit<'buffer> for SyntaxEditor<'_, 'buffer> {
     fn buffer_ref(&self) -> &BufferRef<'buffer> {
         self.editor.buffer_ref()
     }
@@ -440,9 +440,7 @@ impl<'syntax_system, 'buffer> Edit<'buffer> for SyntaxEditor<'syntax_system, 'bu
     }
 }
 
-impl<'font_system, 'syntax_system, 'buffer>
-    BorrowedWithFontSystem<'font_system, SyntaxEditor<'syntax_system, 'buffer>>
-{
+impl BorrowedWithFontSystem<'_, SyntaxEditor<'_, '_>> {
     /// Load text from a file, and also set syntax to the best option
     ///
     /// ## Errors

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -140,7 +140,7 @@ impl<'a> FontFallbackIter<'a> {
     }
 }
 
-impl<'a> Iterator for FontFallbackIter<'a> {
+impl Iterator for FontFallbackIter<'_> {
     type Item = Arc<Font>;
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(fallback_info) = self.font_system.monospace_fallbacks_buffer.pop_first() {

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -185,11 +185,11 @@ mod test {
         let now = std::time::Instant::now();
 
         let mut db = fontdb::Database::new();
-        let locale = get_locale().unwrap();
+        let locale = get_locale().expect("Local available");
         db.load_system_fonts();
         FontSystem::new_with_locale_and_db(locale, db);
 
         #[cfg(not(target_arch = "wasm32"))]
-        println!("Fonts load time {}ms.", now.elapsed().as_millis())
+        println!("Fonts load time {}ms.", now.elapsed().as_millis());
     }
 }

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -106,7 +106,7 @@ pub struct FontSystem {
     /// Scratch buffer for shaping and laying out.
     pub(crate) shape_buffer: ShapeBuffer,
 
-    /// Buffer for use in FontFallbackIter.
+    /// Buffer for use in `FontFallbackIter`.
     pub(crate) monospace_fallbacks_buffer: BTreeSet<MonospaceFallbackInfo>,
 
     /// Cache for shaped runs
@@ -372,7 +372,7 @@ pub struct BorrowedWithFontSystem<'a, T> {
     pub(crate) font_system: &'a mut FontSystem,
 }
 
-impl<'a, T> Deref for BorrowedWithFontSystem<'a, T> {
+impl<T> Deref for BorrowedWithFontSystem<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -380,7 +380,7 @@ impl<'a, T> Deref for BorrowedWithFontSystem<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for BorrowedWithFontSystem<'a, T> {
+impl<T> DerefMut for BorrowedWithFontSystem<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -28,7 +28,7 @@ pub struct LayoutGlyph {
     pub y: f32,
     /// Width of hitbox
     pub w: f32,
-    /// Unicode BiDi embedding level, character is left-to-right if `level` is divisible by 2
+    /// Unicode `BiDi` embedding level, character is left-to-right if `level` is divisible by 2
     pub level: unicode_bidi::Level,
     /// X offset in line
     ///
@@ -58,7 +58,7 @@ pub struct LayoutGlyph {
 
 #[derive(Clone, Debug)]
 pub struct PhysicalGlyph {
-    /// Cache key, see [CacheKey]
+    /// Cache key, see [`CacheKey`]
     pub cache_key: CacheKey,
     /// Integer component of X offset in line
     pub x: i32,

--- a/src/line_ending.rs
+++ b/src/line_ending.rs
@@ -48,11 +48,11 @@ impl<'a> LineIter<'a> {
     }
 }
 
-impl<'a> Iterator for LineIter<'a> {
+impl Iterator for LineIter<'_> {
     type Item = (Range<usize>, LineEnding);
     fn next(&mut self) -> Option<Self::Item> {
         let start = self.start;
-        match self.string[start..self.end].find(&['\r', '\n']) {
+        match self.string[start..self.end].find(['\r', '\n']) {
             Some(i) => {
                 let end = start + i;
                 self.start = end;

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1249,7 +1249,8 @@ impl ShapeLine {
                                 let trailing_blank = span
                                     .words
                                     .get(i + 1)
-                                    .map_or(false, |previous_word| previous_word.blank);
+                                    .is_some_and(|previous_word| previous_word.blank);
+
                                 if trailing_blank {
                                     number_of_blanks = number_of_blanks.saturating_sub(1);
                                     add_to_visual_line(

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -384,12 +384,8 @@ fn shape_run_cached(
             // Skip if attrs matches default attrs
             continue;
         }
-        let start = max(attrs_range.start, start_run)
-            .checked_sub(start_run)
-            .unwrap_or(0);
-        let end = min(attrs_range.end, end_run)
-            .checked_sub(start_run)
-            .unwrap_or(0);
+        let start = max(attrs_range.start, start_run).saturating_sub(start_run);
+        let end = min(attrs_range.end, end_run).saturating_sub(start_run);
         if end > start {
             let range = start..end;
             key.attrs_spans.push((range, attrs.clone()));

--- a/src/shape_run_cache.rs
+++ b/src/shape_run_cache.rs
@@ -33,7 +33,7 @@ impl ShapeRunCache {
         self.cache.insert(key, (self.age, glyphs));
     }
 
-    /// Remove anything in the cache with an age older than keep_ages
+    /// Remove anything in the cache with an age older than `keep_ages`
     pub fn trim(&mut self, keep_ages: u64) {
         self.cache
             .retain(|_key, (age, _glyphs)| *age + keep_ages >= self.age);


### PR DESCRIPTION
Hello! I've done some grunt work to resolve the existing lints in this repo. 

## MSRV
The verifiable crate MSRV is 1.75.

This is largely due to the swash dependency, and may be a side-effect of adding `Cargo.lock` to `.gitignore`. Adding the lockfile back to the crate, alongside some CI that will verify the MSRV, should prevent violations of this.

This check can be reproduced with `cargo-msrv`, or by using an older rust version.
