### PR TITLE
Fix glyph start+end indices in `Basic` shaping

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -455,8 +455,8 @@ fn shape_skip(
             let attrs = attrs_list.get_span(start_run + chr_idx);
 
             ShapeGlyph {
-                start: i,
-                end: i + 1,
+                start: i + start_run,
+                end: i + start_run + 1,
                 x_advance,
                 y_advance: 0.0,
                 x_offset: 0.0,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -448,31 +448,33 @@ fn shape_skip(
     let ascent = metrics.ascent / f32::from(metrics.units_per_em);
     let descent = metrics.descent / f32::from(metrics.units_per_em);
 
-    glyphs.extend(line[start_run..end_run].char_indices().enumerate().map(
-        |(i, (chr_idx, codepoint))| {
-            let glyph_id = charmap.map(codepoint);
-            let x_advance = glyph_metrics.advance_width(glyph_id);
-            let attrs = attrs_list.get_span(start_run + chr_idx);
+    glyphs.extend(
+        line[start_run..end_run]
+            .char_indices()
+            .map(|(chr_idx, codepoint)| {
+                let glyph_id = charmap.map(codepoint);
+                let x_advance = glyph_metrics.advance_width(glyph_id);
+                let attrs = attrs_list.get_span(start_run + chr_idx);
 
-            ShapeGlyph {
-                start: i + start_run,
-                end: i + start_run + 1,
-                x_advance,
-                y_advance: 0.0,
-                x_offset: 0.0,
-                y_offset: 0.0,
-                ascent,
-                descent,
-                font_monospace_em_width,
-                font_id,
-                glyph_id,
-                color_opt: attrs.color_opt,
-                metadata: attrs.metadata,
-                cache_key_flags: attrs.cache_key_flags,
-                metrics_opt: attrs.metrics_opt.map(|x| x.into()),
-            }
-        },
-    ));
+                ShapeGlyph {
+                    start: chr_idx + start_run,
+                    end: chr_idx + start_run + codepoint.len_utf8(),
+                    x_advance,
+                    y_advance: 0.0,
+                    x_offset: 0.0,
+                    y_offset: 0.0,
+                    ascent,
+                    descent,
+                    font_monospace_em_width,
+                    font_id,
+                    glyph_id,
+                    color_opt: attrs.color_opt,
+                    metadata: attrs.metadata,
+                    cache_key_flags: attrs.cache_key_flags,
+                    metrics_opt: attrs.metrics_opt.map(|x| x.into()),
+                }
+            }),
+    );
 }
 
 /// A shaped glyph


### PR DESCRIPTION
Resolves https://github.com/pop-os/cosmic-text/issues/321.

These indices were previously relative to the start of the *run* in units of codepoints, when they should be relative to the start of the *line* in units of bytes.

You can see this in the `rich-text` example if you change `Shaping::Advanced` to `Shaping::Basic` and select some text:

https://github.com/user-attachments/assets/00eacb34-e12f-453e-b704-3cab2e5f21f9

And with the fix applied:

https://github.com/user-attachments/assets/c1b3d3ed-3668-48ab-981d-aefc5792b9ae


