### PR TITLE
Fix build for android targets

### DIFF
--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -9,7 +9,7 @@ use crate::{Font, FontMatchKey, FontSystem, ShapeBuffer};
 
 use self::platform::*;
 
-#[cfg(not(any(unix, target_os = "windows")))]
+#[cfg(not(any(all(unix, not(target_os = "android")), target_os = "windows")))]
 #[path = "other.rs"]
 mod platform;
 


### PR DESCRIPTION
`cosmic-text` doesn't seem to be building for android.

Fixes #349 

```
error[E0432]: unresolved import `self::platform`
  --> /Users/me/src/cosmic-text/src/font/fallback/mod.rs:10:11
   |
10 | use self::platform::*;
   |           ^^^^^^^^ could not find `platform` in `self`
```

I found that reverting 829a59bd9567b1ce1dd38c2fd527cf9ff838625b seems to fix the issue. I tried to wrangle the `cfg` directives to make sure android gets `platform`. I'm not 100% confident this is the correct fix and I'm not really sure how to test with these other platforms. Please feel free to close for an alternative fix.

To reproduce, I am attempting to build Bevy for android following the [instructions](https://github.com/bevyengine/bevy/blob/main/examples/README.md#android) from the examples readme.

```
git clone https://github.com/rparrett/bevy --single-branch cosmic-13
cd cosmic-13/examples/mobile
rustup target add aarch64-linux-android
cargo install cargo-ndk
cargo ndk -t arm64-v8a -o android_example/app/src/main/jniLibs build
```


