### PR TITLE
Configurable font fallback lists

### DIFF
--- a/src/font/fallback/macos.rs
+++ b/src/font/fallback/macos.rs
@@ -2,8 +2,31 @@
 
 use unicode_script::Script;
 
+use super::Fallback;
+
+/// A platform-specific font fallback list, for MacOS.
+pub struct PlatformFallback;
+
+impl Fallback for PlatformFallback {
+    fn common_fallback(&self) -> &'static [&'static str] {
+        common_fallback()
+    }
+
+    fn forbidden_fallback(&self) -> &'static [&'static str] {
+        forbidden_fallback()
+    }
+
+    fn script_fallback(
+        &self,
+        script: unicode_script::Script,
+        locale: &str,
+    ) -> &'static [&'static str] {
+        script_fallback(script, locale)
+    }
+}
+
 // Fallbacks to use after any script specific fallbacks
-pub fn common_fallback() -> &'static [&'static str] {
+fn common_fallback() -> &'static [&'static str] {
     &[
         ".SF NS",
         "Menlo",
@@ -14,7 +37,7 @@ pub fn common_fallback() -> &'static [&'static str] {
 }
 
 // Fallbacks to never use
-pub fn forbidden_fallback() -> &'static [&'static str] {
+fn forbidden_fallback() -> &'static [&'static str] {
     &[".LastResort"]
 }
 
@@ -34,7 +57,7 @@ fn han_unification(locale: &str) -> &'static [&'static str] {
 }
 
 // Fallbacks to use per script
-pub fn script_fallback(script: Script, locale: &str) -> &'static [&'static str] {
+fn script_fallback(script: Script, locale: &str) -> &'static [&'static str] {
     //TODO: abstract style (sans/serif/monospaced)
     //TODO: pull more data from about:config font.name-list.sans-serif in Firefox
     match script {

--- a/src/font/fallback/macos.rs
+++ b/src/font/fallback/macos.rs
@@ -5,6 +5,7 @@ use unicode_script::Script;
 use super::Fallback;
 
 /// A platform-specific font fallback list, for MacOS.
+#[derive(Debug)]
 pub struct PlatformFallback;
 
 impl Fallback for PlatformFallback {

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -36,7 +36,7 @@ pub trait Fallback {
 }
 
 #[derive(Debug, Default)]
-pub struct Fallbacks {
+pub(crate) struct Fallbacks {
     lists: Vec<&'static str>,
     common_fallback_range: Range<usize>,
     forbidden_fallback_range: Range<usize>,

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -24,6 +24,45 @@ mod platform;
 #[path = "windows.rs"]
 mod platform;
 
+/// The `Fallback` trait allows for configurable font fallback lists to be set during construction of the [`FontSystem`].
+///
+/// A custom fallback list can be added via the [`FontSystem::new_with_locale_and_db_and_fallback`] constructor.
+///
+/// A default implementation is provided by the [`PlatformFallback`] struct, which encapsulates the target platform's pre-configured fallback lists.
+///
+/// ```rust
+/// # use unicode_script::Script;
+/// # use cosmic_text::{Fallback, FontSystem};
+/// struct MyFallback;
+/// impl Fallback for MyFallback {
+///     fn common_fallback(&self) -> &[&'static str] {
+///         &[
+///             "Segoe UI",
+///             "Segoe UI Emoji",
+///             "Segoe UI Symbol",
+///             "Segoe UI Historic",
+///         ]
+///     }
+///
+///     fn forbidden_fallback(&self) -> &[&'static str] {
+///         &[]
+///     }
+///
+///     fn script_fallback(&self, script: Script, locale: &str) -> &[&'static str] {
+///         match script {
+///             Script::Adlam => &["Ebrima"],
+///             Script::Bengali => &["Nirmala UI"],
+///             Script::Canadian_Aboriginal => &["Gadugi"],
+///             // ...
+///             _ => &[],
+///        }
+///     }
+/// }
+///
+/// let locale = "en-US".to_string();
+/// let db = fontdb::Database::new();
+/// let font_system = FontSystem::new_with_locale_and_db_and_fallback(locale, db, MyFallback);
+/// ```
 pub trait Fallback {
     /// Fallbacks to use after any script specific fallbacks
     fn common_fallback(&self) -> &[&'static str];

--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use alloc::borrow::ToOwned;
+use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::{mem, ops::Range};

--- a/src/font/fallback/other.rs
+++ b/src/font/fallback/other.rs
@@ -5,6 +5,7 @@ use unicode_script::Script;
 use super::Fallback;
 
 /// An empty platform-specific font fallback list.
+#[derive(Debug)]
 pub struct PlatformFallback;
 
 impl Fallback for PlatformFallback {

--- a/src/font/fallback/other.rs
+++ b/src/font/fallback/other.rs
@@ -2,17 +2,40 @@
 
 use unicode_script::Script;
 
+use super::Fallback;
+
+/// An empty platform-specific font fallback list.
+pub struct PlatformFallback;
+
+impl Fallback for PlatformFallback {
+    fn common_fallback(&self) -> &'static [&'static str] {
+        common_fallback()
+    }
+
+    fn forbidden_fallback(&self) -> &'static [&'static str] {
+        forbidden_fallback()
+    }
+
+    fn script_fallback(
+        &self,
+        script: unicode_script::Script,
+        locale: &str,
+    ) -> &'static [&'static str] {
+        script_fallback(script, locale)
+    }
+}
+
 // Fallbacks to use after any script specific fallbacks
-pub fn common_fallback() -> &'static [&'static str] {
+fn common_fallback() -> &'static [&'static str] {
     &[]
 }
 
 // Fallbacks to never use
-pub fn forbidden_fallback() -> &'static [&'static str] {
+fn forbidden_fallback() -> &'static [&'static str] {
     &[]
 }
 
 // Fallbacks to use per script
-pub fn script_fallback(_script: Script, _locale: &str) -> &'static [&'static str] {
+fn script_fallback(_script: Script, _locale: &str) -> &'static [&'static str] {
     &[]
 }

--- a/src/font/fallback/unix.rs
+++ b/src/font/fallback/unix.rs
@@ -2,8 +2,31 @@
 
 use unicode_script::Script;
 
+use super::Fallback;
+
+/// A platform-specific font fallback list, for Unix.
+pub struct PlatformFallback;
+
+impl Fallback for PlatformFallback {
+    fn common_fallback(&self) -> &'static [&'static str] {
+        common_fallback()
+    }
+
+    fn forbidden_fallback(&self) -> &'static [&'static str] {
+        forbidden_fallback()
+    }
+
+    fn script_fallback(
+        &self,
+        script: unicode_script::Script,
+        locale: &str,
+    ) -> &'static [&'static str] {
+        script_fallback(script, locale)
+    }
+}
+
 // Fallbacks to use after any script specific fallbacks
-pub fn common_fallback() -> &'static [&'static str] {
+fn common_fallback() -> &'static [&'static str] {
     //TODO: abstract style (sans/serif/monospaced)
     &[
         /* Sans-serif fallbacks */
@@ -25,7 +48,7 @@ pub fn common_fallback() -> &'static [&'static str] {
 }
 
 // Fallbacks to never use
-pub fn forbidden_fallback() -> &'static [&'static str] {
+fn forbidden_fallback() -> &'static [&'static str] {
     &[]
 }
 
@@ -45,7 +68,7 @@ fn han_unification(locale: &str) -> &'static [&'static str] {
 }
 
 // Fallbacks to use per script
-pub fn script_fallback(script: Script, locale: &str) -> &'static [&'static str] {
+fn script_fallback(script: Script, locale: &str) -> &'static [&'static str] {
     //TODO: abstract style (sans/serif/monospaced)
     match script {
         Script::Adlam => &["Noto Sans Adlam", "Noto Sans Adlam Unjoined"],

--- a/src/font/fallback/unix.rs
+++ b/src/font/fallback/unix.rs
@@ -5,7 +5,7 @@ use unicode_script::Script;
 use super::Fallback;
 
 /// A platform-specific font fallback list, for Unix.
-pub struct PlatformFallback;
+#[derive(Debug)] pub struct PlatformFallback;
 
 impl Fallback for PlatformFallback {
     fn common_fallback(&self) -> &'static [&'static str] {

--- a/src/font/fallback/unix.rs
+++ b/src/font/fallback/unix.rs
@@ -5,7 +5,8 @@ use unicode_script::Script;
 use super::Fallback;
 
 /// A platform-specific font fallback list, for Unix.
-#[derive(Debug)] pub struct PlatformFallback;
+#[derive(Debug)]
+pub struct PlatformFallback;
 
 impl Fallback for PlatformFallback {
     fn common_fallback(&self) -> &'static [&'static str] {

--- a/src/font/fallback/windows.rs
+++ b/src/font/fallback/windows.rs
@@ -5,6 +5,7 @@ use unicode_script::Script;
 use super::Fallback;
 
 /// A platform-specific font fallback list, for Windows.
+#[derive(Debug)]
 pub struct PlatformFallback;
 
 impl Fallback for PlatformFallback {

--- a/src/font/fallback/windows.rs
+++ b/src/font/fallback/windows.rs
@@ -2,8 +2,31 @@
 
 use unicode_script::Script;
 
+use super::Fallback;
+
+/// A platform-specific font fallback list, for Windows.
+pub struct PlatformFallback;
+
+impl Fallback for PlatformFallback {
+    fn common_fallback(&self) -> &'static [&'static str] {
+        common_fallback()
+    }
+
+    fn forbidden_fallback(&self) -> &'static [&'static str] {
+        forbidden_fallback()
+    }
+
+    fn script_fallback(
+        &self,
+        script: unicode_script::Script,
+        locale: &str,
+    ) -> &'static [&'static str] {
+        script_fallback(script, locale)
+    }
+}
+
 // Fallbacks to use after any script specific fallbacks
-pub fn common_fallback() -> &'static [&'static str] {
+fn common_fallback() -> &'static [&'static str] {
     //TODO: abstract style (sans/serif/monospaced)
     &[
         "Segoe UI",
@@ -15,7 +38,7 @@ pub fn common_fallback() -> &'static [&'static str] {
 }
 
 // Fallbacks to never use
-pub fn forbidden_fallback() -> &'static [&'static str] {
+fn forbidden_fallback() -> &'static [&'static str] {
     &[]
 }
 
@@ -36,7 +59,7 @@ fn han_unification(locale: &str) -> &'static [&'static str] {
 }
 
 // Fallbacks to use per script
-pub fn script_fallback(script: Script, locale: &str) -> &'static [&'static str] {
+fn script_fallback(script: Script, locale: &str) -> &'static [&'static str] {
     //TODO: better match https://github.com/chromium/chromium/blob/master/third_party/blink/renderer/platform/fonts/win/font_fallback_win.cc#L99
     match script {
         Script::Adlam => &["Ebrima"],

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pub(crate) mod fallback;
 
 // re-export ttf_parser
 pub use ttf_parser;
@@ -12,6 +11,9 @@ use alloc::vec::Vec;
 
 use rustybuzz::Face as RustybuzzFace;
 use self_cell::self_cell;
+
+pub(crate) mod fallback;
+pub use fallback::{Fallback, PlatformFallback};
 
 pub use self::system::*;
 mod system;

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -116,9 +116,6 @@ pub struct FontSystem {
 
     /// List of fallbacks
     pub(crate) fallbacks: Box<dyn Fallback>,
-
-    /// Scratch buffer for fallback list
-    pub(crate) scratch_fallbacks: Vec<&'static str>,
 }
 
 impl fmt::Debug for FontSystem {
@@ -216,7 +213,6 @@ impl FontSystem {
             shape_run_cache: crate::ShapeRunCache::default(),
             shape_buffer: ShapeBuffer::default(),
             fallbacks: Box::new(fallbacks),
-            scratch_fallbacks: Vec::new(),
         }
     }
 

--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -116,6 +116,9 @@ pub struct FontSystem {
 
     /// List of fallbacks
     pub(crate) fallbacks: Box<dyn Fallback>,
+
+    /// Scratch buffer for fallback list
+    pub(crate) scratch_fallbacks: Vec<&'static str>,
 }
 
 impl fmt::Debug for FontSystem {
@@ -213,6 +216,7 @@ impl FontSystem {
             shape_run_cache: crate::ShapeRunCache::default(),
             shape_buffer: ShapeBuffer::default(),
             fallbacks: Box::new(fallbacks),
+            scratch_fallbacks: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Fixes #126

A configurable font fallback list can be set by the user during construction of the `FontSystem`.

Commit #0fb1cadb essentially preserves the exact existing behaviour. The further commits after that allow for non-static fallback lists (i.e. not known at compile-time), however these names are still `&'static str`.

Changes to the public API:

1. A new trait `Fallback`.
1. A new constructor `FontSystem::new_with_locale_and_db_and_fallback`, allowing you to pass in a type that implements `Fallback`.
1. A new struct `PlatformFallback` that implements `Fallback`, which encapsulates the existing platform-specific fallback lists in `src/font/fallback/windows.rs` etc.

At `FontSystem` construction, the fallback lists are collected into a private `Fallbacks` struct, which is done to limit the number of times the `Box<dyn Fallback>` is accessed. Each time the `FontFallbackIter` is constructed, the `Fallbacks` struct is extended with the relevant script-specific fallback lists.

In my tests, there is a small regression in performance in `Wrap(None, Simple)`, but no regression in all the other benchmarks, and even supposed performance improvement in some of the more complex text benchmarks but I can't see how this could be the case.

# Possible future work

1. The names of the fonts are currently `&'static str`, but this could be expanded to `&str`, for more run-time configurability.
1. It is possible to eliminate the `Box<dyn Fallback>`, if the `Fallback` trait adds a `supported_scripts` method, then at `FontSystem` construction time, enumerates the supported scripts and their fallback lists, also eliminating the need to extend the `Fallbacks` struct each time the `FontFallbackIter` is constructed.
1. The trait methods could return iterators instead of slices, for more flexibility.
1. A different storage/lookup mechanism for the `script_fallbacks` (instead of the current `HashMap`) could theoretically be worthwhile for performance.
1. Going in the other direction, there could be more dynamic/bespoke behaviour rather than these effectively flat lists of fallback fonts.
