### PR TITLE
Add letter spacing support

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -2,10 +2,10 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::hash::{Hash, Hasher};
 use core::ops::Range;
 use rangemap::RangeMap;
 use smol_str::SmolStr;
-use std::hash::{Hash, Hasher};
 
 use crate::{CacheKeyFlags, Metrics};
 
@@ -169,7 +169,7 @@ pub struct Attrs<'a> {
     pub metadata: usize,
     pub cache_key_flags: CacheKeyFlags,
     pub metrics_opt: Option<CacheMetrics>,
-    /// Letter spacing (tracking) in pixels
+    /// Letter spacing (tracking) in EM
     pub letter_spacing_opt: Option<LetterSpacing>,
 }
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -155,11 +155,6 @@ fn shape_fallback(
     glyphs.reserve(glyph_infos.len());
     let glyph_start = glyphs.len();
     for (info, pos) in glyph_infos.iter().zip(glyph_positions.iter()) {
-        let x_advance = pos.x_advance as f32 / font_scale;
-        let y_advance = pos.y_advance as f32 / font_scale;
-        let x_offset = pos.x_offset as f32 / font_scale;
-        let y_offset = pos.y_offset as f32 / font_scale;
-
         let start_glyph = start_run + info.cluster as usize;
 
         if info.glyph_id == 0 {
@@ -167,6 +162,12 @@ fn shape_fallback(
         }
 
         let attrs = attrs_list.get_span(start_glyph);
+        let x_advance = pos.x_advance as f32 / font_scale
+            + attrs.letter_spacing_opt.map_or(0.0, |spacing| spacing.0);
+        let y_advance = pos.y_advance as f32 / font_scale;
+        let x_offset = pos.x_offset as f32 / font_scale;
+        let y_offset = pos.y_offset as f32 / font_scale;
+
         glyphs.push(ShapeGlyph {
             start: start_glyph,
             end: end_run, // Set later
@@ -453,7 +454,8 @@ fn shape_skip(
             .char_indices()
             .map(|(chr_idx, codepoint)| {
                 let glyph_id = charmap.map(codepoint);
-                let x_advance = glyph_metrics.advance_width(glyph_id);
+                let x_advance = glyph_metrics.advance_width(glyph_id)
+                    + attrs.letter_spacing_opt.map_or(0.0, |spacing| spacing.0);
                 let attrs = attrs_list.get_span(start_run + chr_idx);
 
                 ShapeGlyph {


### PR DESCRIPTION
Add in support for letter spacing equivalent to https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing , however it's defined only in em rather than being able to supply both px or em. Letter spacing adds a uniform additional spacing between glyphs. So it does not replace kerning or other spacing logic, but rather augments it. Unless the user specifies a non-zero letter spacing value the current logic remains the same.

Resolves a request for it under https://github.com/pop-os/cosmic-text/discussions/368

<img width="481" alt="Screenshot 2025-03-28 at 4 40 56 pm" src="https://github.com/user-attachments/assets/b149f80c-e471-4af8-8ff5-24ae3a86dc46" />