### PR TITLE
Store font as peniko::Font behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,16 @@ version = "0.3.13"
 default-features = false
 features = ["hardcoded-data"]
 
+[dependencies.peniko]
+version = "0.3.1"
+optional = true
+
 [features]
 default = ["std", "swash", "fontconfig"]
 fontconfig = ["fontdb/fontconfig", "std"]
 monospace_fallback = []
 no_std = ["rustybuzz/libm", "hashbrown", "dep:libm"]
+peniko = ["dep:peniko"]
 shape-run-cache = []
 std = [
     "fontdb/memmap",

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -91,8 +91,8 @@ impl Font {
     }
 
     #[cfg(feature = "peniko")]
-    pub fn peniko(&self) -> &peniko::Font {
-        &self.data
+    pub fn as_peniko(&self) -> peniko::Font {
+        self.data.clone()
     }
 
     #[cfg(feature = "swash")]

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -91,7 +91,7 @@ impl Font {
     }
 
     #[cfg(feature = "peniko")]
-    pub fn as_peniko(&self) -> &peniko::Font {
+    pub fn peniko(&self) -> &peniko::Font {
         &self.data
     }
 

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -189,7 +189,7 @@ impl Font {
             #[cfg(not(feature = "peniko"))]
             data,
             #[cfg(feature = "peniko")]
-            data: peniko::Font::new(peniko::Blob::new(data), info.index)
+            data: peniko::Font::new(peniko::Blob::new(data), info.index),
         })
     }
 }

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -2,6 +2,9 @@
 
 // re-export ttf_parser
 pub use ttf_parser;
+// re-export peniko::Font;
+#[cfg(feature = "peniko")]
+pub use peniko::Font as PenikoFont;
 
 use core::fmt;
 
@@ -91,7 +94,7 @@ impl Font {
     }
 
     #[cfg(feature = "peniko")]
-    pub fn as_peniko(&self) -> peniko::Font {
+    pub fn as_peniko(&self) -> PenikoFont {
         self.data.clone()
     }
 


### PR DESCRIPTION
## Intent

Behind a feature flag, allow fonts to be stored and retrieved as `peniko::Font`.

## Background

I work with @StewartCanva on a part of our renderer that interfaces with [Vello](https://github.com/linebender/vello). To allow Cosmic Text to interface with the Linebender stack, it's preferable to store font data using [`peniko::Font`](https://github.com/linebender/peniko/blob/615caa3fdb0df9e8396e4efe4ab89fe8e1a872a7/src/font.rs#L8). Otherwise, we'd likely need to doubly allocate font data, which is something we'd very much like to avoid.