### PR TITLE
make MSRV accurate again

### DIFF
--- a/src/font/fallback/mod.rs
+++ b/src/font/fallback/mod.rs
@@ -109,7 +109,7 @@ impl Fallbacks {
         let forbidden_fallback_range = new_range(&lists);
 
         let mut script_fallback_ranges =
-            HashMap::with_capacity_and_hasher(scripts.len(), BuildHasher::new());
+            HashMap::with_capacity_and_hasher(scripts.len(), BuildHasher::default());
         for &script in scripts {
             let script_fallback = fallbacks.script_fallback(script, locale);
             lists.extend_from_slice(script_fallback);


### PR DESCRIPTION
Fixes #380 

I introduced this issue in #369

Before this fix:
```
E:\Dev\cosmic-text> cargo msrv verify                                                                                                                                                                                                      14/04/25 22:47:38
  [Meta]   cargo-msrv 0.18.4

Compatibility Check #1: Rust 1.75.0
  [FAIL]   Is incompatible

  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │     Checking cosmic-text v0.14.1 (E:\Dev\cosmic-text)                                                                                                       │
  │ error[E0599]: no function or associated item named `new` found for struct `BuildHasherDefault` in the current scope                                         │
  │    --> src\font\fallback\mod.rs:112:75                                                                                                                      │
  │     |                                                                                                                                                       │
  │ 112 |             HashMap::with_capacity_and_hasher(scripts.len(), BuildHasher::new());                                                                     │
  │     |                                                                           ^^^ function or associated item not found in `BuildHasherDefault<FxHasher>` │
  │                                                                                                                                                             │
  │ For more information about this error, try `rustc --explain E0599`.                                                                                         │
  │ error: could not compile `cosmic-text` (lib) due to previous error                                                                                          │
  │                                                                                                                                                             │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯



Crate source was found to be incompatible with Rust version '1.75.0' specified as MSRV in the Cargo manifest located at 'E:\Dev\cosmic-text\Cargo.toml'
```

After this fix:
```
E:\Dev\cosmic-text> cargo msrv verify                                                                                                                                                                                                       14/04/25 22:45:46
  [Meta]   cargo-msrv 0.18.4

Compatibility Check #1: Rust 1.75.0
  [OK]     Is compatible
```