### PR TITLE
fontdb 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75"
 [dependencies]
 bitflags = "2.4.1"
 cosmic_undo_2 = { version = "0.2.0", optional = true }
-fontdb = { version = "0.16", default-features = false }
+fontdb = { version = "0.23", default-features = false }
 hashbrown = { version = "0.14.1", optional = true, default-features = false }
 libm = { version = "0.2.8", optional = true }
 log = "0.4.20"

--- a/benches/layout.rs
+++ b/benches/layout.rs
@@ -26,7 +26,7 @@ fn layout(c: &mut Criterion) {
 
             let mut run_on_text = |text: &str| {
                 buffer.lines.clear();
-                buffer.set_text(&mut fs, text, ct::Attrs::new(), *shape);
+                buffer.set_text(&mut fs, text, &ct::Attrs::new(), *shape);
                 buffer.shape_until_scroll(&mut fs, false);
             };
 


### PR DESCRIPTION
Bump fontdb, no change otherwise. fontdb is a re-export of cosmic-text though so I guess this is technically a breaking change. Also discovered the bench was broken.

Possibly fixes #379 through better handling of empty fontconfig; @inferrna please confirm.
