### PR TITLE
Round glyph advance to integer sizes

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1559,12 +1559,13 @@ impl ShapeLine {
                                 _ => font_size,
                             };
 
-                            let x_advance = glyph_font_size * glyph.x_advance
+                            let mut x_advance = glyph_font_size * glyph.x_advance
                                 + if word.blank {
                                     justification_expansion
                                 } else {
                                     0.0
                                 };
+                            x_advance = x_advance.round();
                             if self.rtl {
                                 x -= x_advance;
                             }


### PR DESCRIPTION
This is in line with [1].

[1]: https://skia.googlesource.com/skia/+/refs/heads/chrome/m136/src/ports/SkTypeface_fontations.cpp#539

Fixes

![image](https://github.com/user-attachments/assets/a7ef59d3-4edd-4b5d-831a-62a5760e65c1)

->

![image](https://github.com/user-attachments/assets/0c6710ce-5eae-4de7-8e43-1ca4e2302d9c)