### PR TITLE
Fix wrap_word_fallback test: avoid temporary borrow, improve clarity

### DIFF
--- a/tests/wrap_word_fallback.rs
+++ b/tests/wrap_word_fallback.rs
@@ -1,38 +1,56 @@
-use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, Wrap};
+use cosmic_text::{Attrs, Buffer, Family, FontSystem, Metrics, Shaping, Wrap};
 
-// Tests the ability to fallback to glyph wrapping when a word can't fit on a line by itself.
-// No line should ever overflow the buffer size.
 #[test]
 fn wrap_word_fallback() {
+    // Create a new font database and font system
     let mut font_system =
         FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
-    let font = std::fs::read("fonts/Inter-Regular.ttf")
-        .expect("Failed to read inter-regular.ttf font file");
-    font_system.db_mut().load_font_data(font);
+
+    // Load the Inter font from file — this registers the family name
+    font_system
+        .db_mut()
+        .load_font_file("fonts/Inter-Regular.ttf")
+        .expect("Failed to load Inter-Regular.ttf");
+
+    // Setup text layout metrics
     let metrics = Metrics::new(14.0, 20.0);
 
+    // Create and borrow the buffer
     let mut buffer_base = Buffer::new(&mut font_system, metrics);
     let mut buffer = buffer_base.borrow_with(&mut font_system);
 
+    // Enable word or glyph wrapping
     buffer.set_wrap(Wrap::WordOrGlyph);
-    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", &Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced);
+
+    // Use the Inter font family — this will now be resolved properly
+    let attrs = Attrs::new().family(Family::Name("Inter"));
+
+    // Set the test string and shape it
+    buffer.set_text(
+        "Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.",
+        &attrs,
+        Shaping::Advanced,
+    );
+
     buffer.set_size(Some(50.0), Some(1000.0));
     buffer.shape_until_scroll(false);
 
-    let measured_size = measure(&buffer);
-
+    // Measure the longest line width
+    let measured_width = measure(&buffer);
     let buffer_width = buffer.size().0.expect("Buffer width is not set");
 
+    // Ensure the layout does not exceed the buffer width
     assert!(
-        measured_size <= buffer.size().0.unwrap_or(0.0),
+        measured_width <= buffer_width,
         "Measured width is larger than buffer width\n{} <= {}",
-        measured_size,
+        measured_width,
         buffer_width
     );
 }
 
+// Measures the max line width from the buffer
 fn measure(buffer: &Buffer) -> f32 {
     buffer
         .layout_runs()
-        .fold(0.0f32, |width, run| width.max(run.line_w))
+        .fold(0.0, |max_width, run| max_width.max(run.line_w))
 }

--- a/tests/wrap_word_fallback.rs
+++ b/tests/wrap_word_fallback.rs
@@ -17,9 +17,6 @@ fn wrap_word_fallback() {
     buffer.set_wrap(Wrap::WordOrGlyph);
     buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", &Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced);
     buffer.set_size(Some(50.0), Some(1000.0));
-
-    buffer.set_size(Some(50.0), Some(1000.0));
-
     buffer.shape_until_scroll(false);
 
     let measured_size = measure(&buffer);

--- a/tests/wrap_word_fallback.rs
+++ b/tests/wrap_word_fallback.rs
@@ -6,27 +6,31 @@ use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping, Wrap};
 fn wrap_word_fallback() {
     let mut font_system =
         FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
-    let font = std::fs::read("fonts/Inter-Regular.ttf").unwrap();
+    let font = std::fs::read("fonts/Inter-Regular.ttf")
+        .expect("Failed to read inter-regular.ttf font file");
     font_system.db_mut().load_font_data(font);
     let metrics = Metrics::new(14.0, 20.0);
 
-    let mut buffer = Buffer::new(&mut font_system, metrics);
-
-    let mut buffer = buffer.borrow_with(&mut font_system);
+    let mut buffer_base = Buffer::new(&mut font_system, metrics);
+    let mut buffer = buffer_base.borrow_with(&mut font_system);
 
     buffer.set_wrap(Wrap::WordOrGlyph);
     buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", &Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced);
+    buffer.set_size(Some(50.0), Some(1000.0));
+
     buffer.set_size(Some(50.0), Some(1000.0));
 
     buffer.shape_until_scroll(false);
 
     let measured_size = measure(&buffer);
 
+    let buffer_width = buffer.size().0.expect("Buffer width is not set");
+
     assert!(
         measured_size <= buffer.size().0.unwrap_or(0.0),
         "Measured width is larger than buffer width\n{} <= {}",
         measured_size,
-        buffer.size().0.unwrap_or(0.0)
+        buffer_width
     );
 }
 


### PR DESCRIPTION
### ✅ What this PR does:
- Replaces `.unwrap()` with `.expect(...)` for clearer error output.
- Ensures correct `Option<f32>` usage for `set_size()` and `size()`.
- Minor code cleanups and formatting for improved readability.

### 📦 Why this matters:
The test `wrap_word_fallback` was previously failing due to borrowing from a temporary value. This patch resolves that safely and makes the test easier to debug and maintain.
