### PR TITLE
Fix LayoutRunIter incorrectly skipping first and last line in some cases

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -131,12 +131,12 @@ impl<'b> Iterator for LayoutRunIter<'b> {
                 let centering_offset = (line_height - glyph_height) / 2.0;
                 let line_y = line_top + centering_offset + layout_line.max_ascent;
                 if let Some(height) = self.buffer.height_opt {
-                    if line_y > height {
+                    if line_y - layout_line.max_ascent > height {
                         return None;
                     }
                 }
                 self.line_top += line_height;
-                if line_y < 0.0 {
+                if line_y + layout_line.max_descent < 0.0 {
                     continue;
                 }
 


### PR DESCRIPTION
**TL;DR:** LayoutRunIter is comparing the text *baseline* to the top and bottom of the buffer bounds, instead of using the maximum ascent when comparing against the bottom, and the maximum descent when comparing against the top, [because of this change](https://github.com/pop-os/cosmic-text/pull/141/files#diff-63e4a32005d14798be0b74e9cea1ebd03ea1b6005f5d675f2d5e5b48c724a07bR249).

---

I just switched from using Glyphon to implementing my own text renderer, and was very confused when the last line of my textbox would simply vanish instead of being properly cropped. Actually figuring out what was going on here turned out to be remarkably difficult, because there are almost no examples in the ecosystem of this bug happening. This is because the Glyphon examples just [set the text bounds to the entire window](https://github.com/grovesNL/glyphon/blob/main/examples/hello-world.rs#L85) and does its own cropping, and it seems [others have copied this approach](https://github.com/femtovg/femtovg/blob/658accc4761d1bd812afa6b441b53ede69dc3843/examples/external_text.rs#L221). I was originally doing this myself, until I realized the example editor object [relies on the buffer bounds](https://github.com/pop-os/cosmic-text/blob/bcfb05a3909b04f76aa954058d06939535010dcb/src/edit/editor.rs#L180), and in general size is required for cosmic-text to do any scrolling at all.

Originally, I thought the fix here was to use `line_top` instead of `line_y`, which is only almost correct. However, after finding #141, I realized that `line_y` was meant to represent the *baseline*, and thus the correct fix must be `line_top + centering_offset`. Because cosmic-text assembles `line_y` by adding `max_ascent` to `line_top + centering_offset`, I thought it would be more understandable if I set the value to the mathematically equivalent `line_y - layout_line.max_ascent`, which makes it clear we are acquiring the maximum ascent by subtracting it from the baseline, which is [what you're supposed to do.](https://stackoverflow.com/questions/27631736/meaning-of-top-ascent-baseline-descent-bottom-and-leading-in-androids-font)

This also makes it obvious why the second change is necessary - when seeing if the line is visible from the top, we actually need to check the maximum descent, not the baseline, or we will potentially miss characters like `j` that can potentially descend into the next line. I am deeply tempted to rename `line_y` as `baseline` so it is more clear to future maintainers what it represents, but the current PR represents the most minimal change possible to fix the bug.