### PR TITLE
Fix scroll when vertical offset is exactly layout_height

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -465,8 +465,7 @@ impl Buffer {
                 }
 
                 // Adjust scroll.vertical to be smaller by moving scroll.line forwards
-                //TODO: do we want to adjust it exactly to a layout line?
-                if line_i == self.scroll.line && layout_height < self.scroll.vertical {
+                if line_i == self.scroll.line && layout_height <= self.scroll.vertical {
                     self.scroll.line += 1;
                     self.scroll.vertical -= layout_height;
                 }


### PR DESCRIPTION
While testing a textbox that automatically resized itself to the size of its contents, I noticed that it allowed scrolling past the end of the textbox, which was particularly noticeable when there was only one line - it would "scroll past" the single line of text and then try to display nothing at all. 

It turns out that setting the textbox to be the exact size of its contents accidentally triggers the precise edge-case described by this TODO item in the `shape_until_scroll` function. As a result of my testing, I can now say the answer to the question is **yes**, you do in fact need to perform the adjustment when it's exactly equal to a layout line. This fixes the bug, and in my testing, did not affect scrolling behavior in any other cases.