### PR TITLE
Add pixel font flag

### DIFF
--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -9,6 +9,8 @@ bitflags::bitflags! {
         const FAKE_ITALIC = 1;
         /// Disable hinting
         const DISABLE_HINTING = 2;
+        /// Render as a pixel font
+        const PIXEL_FONT = 4;
     }
 }
 

--- a/src/swash.rs
+++ b/src/swash.rs
@@ -34,7 +34,14 @@ fn swash_image(
 
     // Compute the fractional offset-- you'll likely want to quantize this
     // in a real renderer
-    let offset = Vector::new(cache_key.x_bin.as_float(), cache_key.y_bin.as_float());
+    let offset = if cache_key.flags.contains(CacheKeyFlags::PIXEL_FONT) {
+        Vector::new(
+            cache_key.x_bin.as_float().round() + 1.0,
+            cache_key.y_bin.as_float().round(),
+        )
+    } else {
+        Vector::new(cache_key.x_bin.as_float(), cache_key.y_bin.as_float())
+    };
 
     // Select our source order
     Render::new(&[


### PR DESCRIPTION
This fixes #397 at least for the use-case in the issue (the example there now renders pixel-for-pixel the same as Freetype.

I'm not sure if this is a good fix, or if the maths is right, etc etc - any pointers or advice about how to implement this in a way that'll actually work/be useful/able to be merged would be super appreciated!