### PR TITLE
Fixed Tab indenting the line instead of adding Tab or spaces

### DIFF
--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -749,9 +749,9 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                             }
                         }
                     }
-                }
                 // Request redraw
                 self.with_buffer_mut(|buffer| buffer.set_redraw(true));
+                }
             }
             Action::Unindent => {
                 // Get start and end of selection

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -749,8 +749,8 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                             }
                         }
                     }
-                // Request redraw
-                self.with_buffer_mut(|buffer| buffer.set_redraw(true));
+                    // Request redraw
+                    self.with_buffer_mut(|buffer| buffer.set_redraw(true));
                 }
             }
             Action::Unindent => {

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -713,8 +713,14 @@ impl<'buffer> Edit<'buffer> for Editor<'buffer> {
                         required_indent = tab_width;
                     }
 
+                    // Without selection, insert tab at cursor position
+                    let cursor_to_use = match self.selection {
+                         Selection::None => self.cursor,
+                        _ => Cursor::new(line_i, after_whitespace),
+                    };
+
                     self.insert_at(
-                        Cursor::new(line_i, after_whitespace),
+                        cursor_to_use,
                         &" ".repeat(required_indent),
                         None,
                     );


### PR DESCRIPTION
Bug first reported here: pop-os/cosmic-edit#206

I think I've narrowed the issue down to cosmic-text rather than cosmic-edit. The current implementation assumed a selection, even where it could be None, and inserted tabs at the end of leading whitespace.

Re-using the old cursor position in cases where no selections had been made, inserts the tabs at the position where I think most users will expect them.

If this is a sub-par fix, I'll gladly change what is required.