### PR TITLE
Add alignment parameter to set_text

### DIFF
--- a/benches/layout.rs
+++ b/benches/layout.rs
@@ -26,7 +26,7 @@ fn layout(c: &mut Criterion) {
 
             let mut run_on_text = |text: &str| {
                 buffer.lines.clear();
-                buffer.set_text(&mut fs, text, &ct::Attrs::new(), *shape);
+                buffer.set_text(&mut fs, text, &ct::Attrs::new(), *shape, None);
                 buffer.shape_until_scroll(&mut fs, false);
             };
 

--- a/benches/text_shaping_benchmarks.rs
+++ b/benches/text_shaping_benchmarks.rs
@@ -16,6 +16,7 @@ fn bench_ascii_fast_path(c: &mut Criterion) {
                 black_box(&ascii_text),
                 &ct::Attrs::new(),
                 ct::Shaping::Advanced,
+                None,
             );
             buffer.shape_until_scroll(&mut fs, false);
         });
@@ -36,6 +37,7 @@ fn bench_bidi_processing(c: &mut Criterion) {
                 black_box(&bidi_text),
                 &ct::Attrs::new(),
                 ct::Shaping::Advanced,
+                None,
             );
             buffer.shape_until_scroll(&mut fs, false);
         });
@@ -56,6 +58,7 @@ fn bench_layout_heavy(c: &mut Criterion) {
                 black_box(&layout_text),
                 &ct::Attrs::new(),
                 ct::Shaping::Advanced,
+                None,
             );
             buffer.shape_until_scroll(&mut fs, false);
         });
@@ -81,6 +84,7 @@ fn bench_combined_stress(c: &mut Criterion) {
                 black_box(&stress_text),
                 &ct::Attrs::new(),
                 ct::Shaping::Advanced,
+                None,
             );
             buffer.shape_until_scroll(&mut fs, false);
         });

--- a/examples/multiview/src/main.rs
+++ b/examples/multiview/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let attrs = Attrs::new().family(Family::Monospace);
     match fs::read_to_string(&path) {
-        Ok(text) => buffer.set_text(&text, &attrs, Shaping::Advanced),
+        Ok(text) => buffer.set_text(&text, &attrs, Shaping::Advanced, None),
         Err(err) => {
             log::error!("failed to load {:?}: {}", path, err);
         }

--- a/examples/terminal/src/main.rs
+++ b/examples/terminal/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     let text = std::env::args()
         .nth(1)
         .unwrap_or(" Hi, Rust! 🦀 ".to_string());
-    buffer.set_text(&text, &attrs, Shaping::Advanced);
+    buffer.set_text(&text, &attrs, Shaping::Advanced, None);
 
     // Perform shaping as desired
     buffer.shape_until_scroll(true);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -271,7 +271,7 @@ impl Buffer {
     /// Will panic if `metrics.line_height` is zero.
     pub fn new(font_system: &mut FontSystem, metrics: Metrics) -> Self {
         let mut buffer = Self::new_empty(metrics);
-        buffer.set_text(font_system, "", &Attrs::new(), Shaping::Advanced);
+        buffer.set_text(font_system, "", &Attrs::new(), Shaping::Advanced, None);
         buffer
     }
 
@@ -679,6 +679,7 @@ impl Buffer {
         text: &str,
         attrs: &Attrs,
         shaping: Shaping,
+        alignment: Option<Align>,
     ) {
         self.lines.clear();
         for (range, ending) in LineIter::new(text) {
@@ -697,6 +698,13 @@ impl Buffer {
                 shaping,
             ));
         }
+
+        if alignment.is_some() {
+            self.lines.iter_mut().for_each(|line| {
+                line.set_align(alignment);
+            });
+        }
+
         self.scroll = Scroll::default();
         self.shape_until_scroll(font_system, false);
     }
@@ -1424,8 +1432,15 @@ impl BorrowedWithFontSystem<'_, Buffer> {
     }
 
     /// Set text of buffer, using provided attributes for each line by default
-    pub fn set_text(&mut self, text: &str, attrs: &Attrs, shaping: Shaping) {
-        self.inner.set_text(self.font_system, text, attrs, shaping);
+    pub fn set_text(
+        &mut self,
+        text: &str,
+        attrs: &Attrs,
+        shaping: Shaping,
+        alignment: Option<Align>,
+    ) {
+        self.inner
+            .set_text(self.font_system, text, attrs, shaping, alignment);
     }
 
     /// Set text of buffer, using an iterator of styled spans (pairs of text and attributes)

--- a/src/edit/syntect.rs
+++ b/src/edit/syntect.rs
@@ -125,7 +125,7 @@ impl<'syntax_system, 'buffer> SyntaxEditor<'syntax_system, 'buffer> {
 
         let text = fs::read_to_string(path)?;
         self.editor.with_buffer_mut(|buffer| {
-            buffer.set_text(font_system, &text, &attrs, Shaping::Advanced);
+            buffer.set_text(font_system, &text, &attrs, Shaping::Advanced, None);
         });
 
         //TODO: re-use text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! let attrs = Attrs::new();
 //!
 //! // Add some text!
-//! buffer.set_text("Hello, Rust! 🦀\n", &attrs, Shaping::Advanced);
+//! buffer.set_text("Hello, Rust! 🦀\n", &attrs, Shaping::Advanced, None);
 //!
 //! // Perform shaping as desired
 //! buffer.shape_until_scroll(true);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -92,7 +92,7 @@ impl DrawTestCfg {
             Some((self.canvas_width - margins * 2) as f32),
             Some((self.canvas_height - margins * 2) as f32),
         );
-        buffer.set_text(&self.text, &self.font.as_attrs(), Shaping::Advanced);
+        buffer.set_text(&self.text, &self.font.as_attrs(), Shaping::Advanced, None);
         buffer.shape_until_scroll(true);
 
         // Black

--- a/tests/wrap_stability.rs
+++ b/tests/wrap_stability.rs
@@ -105,7 +105,7 @@ fn wrap_extra_line() {
 
     // Add some text!
     buffer.set_wrap(Wrap::Word);
-    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing\n\nweeewoooo minim sint cillum sint consectetur cupidatat.", &Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced);
+    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing\n\nweeewoooo minim sint cillum sint consectetur cupidatat.", &Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced, None);
 
     // Set a size for the text buffer, in pixels
     buffer.set_size(Some(50.0), Some(1000.0));

--- a/tests/wrap_word_fallback.rs
+++ b/tests/wrap_word_fallback.rs
@@ -15,7 +15,7 @@ fn wrap_word_fallback() {
     let mut buffer = buffer.borrow_with(&mut font_system);
 
     buffer.set_wrap(Wrap::WordOrGlyph);
-    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", &Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced);
+    buffer.set_text("Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.", &Attrs::new().family(cosmic_text::Family::Name("Inter")), Shaping::Advanced, None);
     buffer.set_size(Some(50.0), Some(1000.0));
 
     buffer.shape_until_scroll(false);


### PR DESCRIPTION
This is a potential minimal fix for #166, but given that this is an ABI breaking change anyway, I feel what should really happen is that alignment should be added as a parameter to `BufferLine::new()`, which removes the necessity of setting the alignment after you construct the `BufferLine`, but before you shape it, to avoid the performance penalty. An API should encourage the happy path by default, not punish any user that doesn't correctly set the alignment after construction but before the initial shaping by throwing away the initial shaping results.

I also question the use of `Option<>` on an enum that could simply add an `Align::None` or `Align::Default` option, instead, similar to the `Wrap::None` option that already exists.