### PR TITLE
Experiment: Bump Peniko to use Linebender Resource Handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,6 @@ opt-level = 1
 
 [package.metadata.docs.rs]
 features = ["vi"]
+
+[patch.crates-io]
+peniko = { git = "https://github.com/linebender/peniko", rev = "d86ffcd5e5a3853a0a4f57774649e6075424bd6d" }


### PR DESCRIPTION
This is not to be merged, but is instead being used to validate https://github.com/linebender/peniko/pull/129 by running your CI. The `ci.sh` script passes locally, but maybe that misses something that your actions CI catches.

Note that it's likely that Cosmic text will want to replace your Peniko usage with Linebender Resource Handle instead, once Peniko 0.4.1 is out