### PR TITLE
Use `linebender_resource_handle` instead of `peniko`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fontdb = { version = "0.23", default-features = false }
 harfrust = { version = "0.2.0", default-features = false }
 hashbrown = { version = "0.15", optional = true, default-features = false }
 libm = { version = "0.2.8", optional = true }
+linebender_resource_handle = { version = "0.1.1", default-features = false }
 log = "0.4.20"
 modit = { version = "0.1.4", optional = true }
 rangemap = "1.4.0"
@@ -41,21 +42,18 @@ version = "0.3.13"
 default-features = false
 features = ["hardcoded-data"]
 
-[dependencies.peniko]
-version = "0.4.0"
-optional = true
-
 [features]
 default = ["std", "swash", "fontconfig"]
 fontconfig = ["fontdb/fontconfig", "std"]
 monospace_fallback = []
 no_std = ["hashbrown", "dep:libm", "skrifa/libm", "core_maths"]
-peniko = ["dep:peniko"]
+peniko = []
 shape-run-cache = []
 std = [
     "fontdb/memmap",
     "fontdb/std",
     "harfrust/std",
+    "linebender_resource_handle/std",
     "skrifa/std",
     "swash?/std",
     "sys-locale",

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use harfrust::Shaper;
+use linebender_resource_handle::{Blob, FontData};
 use skrifa::raw::{ReadError, TableProvider as _};
 use skrifa::{metrics::Metrics, prelude::*};
 // re-export skrifa
 pub use skrifa;
 // re-export peniko::Font;
 #[cfg(feature = "peniko")]
-pub use peniko::Font as PenikoFont;
+pub use linebender_resource_handle::FontData as PenikoFont;
 
 use core::fmt;
 
@@ -50,10 +51,7 @@ pub struct Font {
     #[cfg(feature = "swash")]
     swash: (u32, swash::CacheKey),
     harfrust: OwnedFace,
-    #[cfg(not(feature = "peniko"))]
-    data: Arc<dyn AsRef<[u8]> + Send + Sync>,
-    #[cfg(feature = "peniko")]
-    data: peniko::Font,
+    data: FontData,
     id: fontdb::ID,
     monospace_fallback: Option<FontMonospaceFallback>,
 }
@@ -88,14 +86,7 @@ impl Font {
     }
 
     pub fn data(&self) -> &[u8] {
-        #[cfg(not(feature = "peniko"))]
-        {
-            (*self.data).as_ref()
-        }
-        #[cfg(feature = "peniko")]
-        {
-            self.data.data.data()
-        }
+        self.data.data.data()
     }
 
     pub fn shaper(&self) -> &harfrust::Shaper<'_> {
@@ -242,10 +233,7 @@ impl Font {
                 },
             )
             .ok()?,
-            #[cfg(not(feature = "peniko"))]
-            data,
-            #[cfg(feature = "peniko")]
-            data: peniko::Font::new(peniko::Blob::new(data), info.index),
+            data: FontData::new(Blob::new(data), info.index),
         })
     }
 }


### PR DESCRIPTION
`linebender_resource_handle` is a new micro-crate containing just the `Font`, `Blob`, and `WeakBlob` types that has been split out of `peniko` to allow for interop without depending on `peniko`. The [semver trick](https://github.com/dtolnay/semver-trick) has been applied which makes this PR non-breaking.

As part of this PR I have made `linebender_resource_handle` a non-optional dependency (but it's publically exposed when the `peniko` feature is enabled and a private implementation detail otherwise). This reduces the amount of conditional compilation required to support the `peniko` feature at the cost of 12 bytes per Font (a `u64` unique ID and a `u32` font index).(and I suspect that cosmic-text ought to be storing the font index for correct TTC support anyway, in which case it's only one `u64` of overhead)

Depends on:
- https://github.com/linebender/raw_resource_handle/pull/11
- https://github.com/linebender/raw_resource_handle/pull/12

to fix compilation on 32bit platforms

---

Note that `Blob` is just:

```rust
struct Blob {
    id: u64, // unique id
    data: Arc<dyn AsRef<[u8]> + Send + Sync>, // What cosmic-text and fontdb use to represent font data anyway
}
```

And `Font` is just:

```rust
struct Font {
      data: Blob,
      index: u32, // index of font inside TTC (or 0 for single-font file)
}
```

    