### PR TITLE
ASCII fast path fix

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -667,8 +667,14 @@ impl ShapeWord {
         let is_simple_ascii =
             word.is_ascii() && !word.chars().any(|c| c.is_ascii_control() && c != '\t');
 
-        if is_simple_ascii && !word.is_empty() {
-            let _attrs = attrs_list.defaults();
+        if is_simple_ascii && !word.is_empty() && {
+            let attrs_start = attrs_list.get_span(word_range.start);
+            attrs_list.spans_iter().all(|(other_range, other_attrs)| {
+                word_range.end <= other_range.start
+                    || other_range.end <= word_range.start
+                    || attrs_start.compatible(&other_attrs.as_attrs())
+            })
+        } {
             shaping.run(
                 &mut glyphs,
                 font_system,


### PR DESCRIPTION
The ASCII fast path in `ShapeWord::build` assumes that the current word has only one attributes span, when it can intersect multiple attribute spans. 

This PR adds a check to ensure that all the attribute spans intersecting the word range are compatible before taking the fast path.

Fixes #445