### PR TITLE
shape: preserve cross-word contextual substitutions for ASCII LTR spans

### DIFF
--- a/tests/shaping_and_rendering.rs
+++ b/tests/shaping_and_rendering.rs
@@ -74,6 +74,97 @@ fn test_english_mixed_with_arabic_paragraph_rendering() {
         .validate_text_rendering();
 }
 
+/// Verify that span-context shaping correctly distributes glyphs to word buckets.
+///
+/// When `should_shape_with_span_context` fires (ASCII, LTR, Advanced shaping, multi-word
+/// span) the whole span is shaped first and its glyphs are split into per-word buckets.
+/// This preserves cross-word OpenType contextual substitutions while still maintaining
+/// the correct word structure for line-wrapping.
+#[test]
+fn test_span_context_shaping_glyph_distribution() {
+    use cosmic_text::{Attrs, Buffer, FontSystem, Metrics, Shaping};
+
+    let mut font_system =
+        FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
+    let font = std::fs::read("fonts/Inter-Regular.ttf").unwrap();
+    font_system.db_mut().load_font_data(font);
+    let metrics = Metrics::new(14.0, 20.0);
+
+    let mut buffer = Buffer::new(&mut font_system, metrics);
+    let mut buffer = buffer.borrow_with(&mut font_system);
+
+    // ASCII LTR multi-word → triggers the span-context path (should_shape_with_span_context=true).
+    let text = "hello world";
+    buffer.set_text(text, &Attrs::new(), Shaping::Advanced, None);
+    buffer.shape_until_scroll(false);
+
+    let line = &buffer.lines[0];
+    let shape = line.shape_opt().expect("ShapeLine not found");
+    let span = &shape.spans[0];
+
+    // "hello world" → "hello" (non-blank), " " (blank), "world" (non-blank)
+    assert_eq!(span.words.len(), 3, "Expected 3 words for 'hello world'");
+    assert!(!span.words[0].blank, "'hello' word must be non-blank");
+    assert!(span.words[1].blank, "space word must be blank");
+    assert!(!span.words[2].blank, "'world' word must be non-blank");
+
+    // Every word must have at least one glyph after the split.
+    for (i, word) in span.words.iter().enumerate() {
+        assert!(
+            !word.glyphs.is_empty(),
+            "word[{i}] has no glyphs (blank={})",
+            word.blank
+        );
+    }
+
+    // Glyph byte offsets must land in the correct region of the line.
+    // "hello"=0..5, " "=5..6, "world"=6..11
+    for glyph in &span.words[0].glyphs {
+        assert!(
+            glyph.start < 5,
+            "'hello' glyph start {} is out of range 0..5",
+            glyph.start
+        );
+    }
+    for glyph in &span.words[1].glyphs {
+        assert!(
+            glyph.start == 5,
+            "space glyph start {} is out of range 5..6",
+            glyph.start
+        );
+    }
+    for glyph in &span.words[2].glyphs {
+        assert!(
+            glyph.start >= 6,
+            "'world' glyph start {} is out of range 6..11",
+            glyph.start
+        );
+    }
+
+    // Shaping::Basic falls through to per-word shaping but must still yield
+    // the same word structure.
+    buffer.set_text(text, &Attrs::new(), Shaping::Basic, None);
+    buffer.shape_until_scroll(false);
+    let line = &buffer.lines[0];
+    let shape = line.shape_opt().expect("ShapeLine not found");
+    let span = &shape.spans[0];
+    assert_eq!(span.words.len(), 3, "Basic shaping should also yield 3 words");
+    assert!(!span.words[0].blank);
+    assert!(span.words[1].blank);
+    assert!(!span.words[2].blank);
+
+    // A single word (no whitespace) must NOT trigger span-context shaping —
+    // should_shape_with_span_context requires both whitespace and non-whitespace.
+    buffer.set_text("hello", &Attrs::new(), Shaping::Advanced, None);
+    buffer.shape_until_scroll(false);
+    let line = &buffer.lines[0];
+    let shape = line.shape_opt().expect("ShapeLine not found");
+    let span = &shape.spans[0];
+    assert_eq!(span.words.len(), 1, "Single word should produce exactly 1 word");
+    assert!(!span.words[0].blank);
+    assert!(!span.words[0].glyphs.is_empty());
+}
+
 #[test]
 fn test_ligature_segmentation() {
     use cosmic_text::{Buffer, FontSystem, Metrics, Shaping};


### PR DESCRIPTION
Hello! First of all: thank you for this cool text layout library that works well in the `wgpu` ecosystem. 

Second: some context. I'm using `cosmic-text` alongside `glyphon` for some text rendering workloads with a bank of fonts, seeking to achieve rendering parity with a rendering system we're using on iOS/swift. I found some differences in the rendering using `cosmic-text` vs. our apple-native font rendering stack using `CATextLayer`. The discrepancy appears to be specifically with cross-span contextual alternatives. 

For example, this is with google fonts' `Mynerve`, there's a discrepancy.

On `CATextLayer`:
<img width="1280" height="384" alt="font_mynerve_regular ttf_expected" src="https://github.com/user-attachments/assets/a40e9b81-d0d9-4a71-adde-8ec02577f00d" />

On `cosmic-text`:

<img width="1280" height="384" alt="font_mynerve_regular ttf_actual" src="https://github.com/user-attachments/assets/13a93cf4-ba4d-43ec-8767-ca36f6b6ab4c" />


If I'm understanding correctly, `cosmic-text` applies contextual alternatives (`calt`) based on word chunks, but we lose contextual alternatives if the span is multi-word or with line breaks due to this word chunking, leading to a discrepancy between native `CATextLayer` rendering and `glyphon` + `cosmic-text` rendering.

So, I came up with this diff with a bit of pair'ing with claude:
* Detect when `Shaping::Advanced` is used on a purely ASCII, LTR, multi-word span, shape the entire span first and then distribute the resulting glyphs into per-word buckets.
* Pretty conservative with the approach: add a `should_shape_with_span_context` guard to keep the fast/original per-word shaping path path for non-ASCII text, RTL runs, Shaping::Basic, and single-word spans.
*  Add a test verifying that glyph byte offsets land in the correct word buckets after the split, and that Shaping::Basic and single-word spans are unaffected.


Thank you for your esteemed code review. Let me know if any changes or more info is needed or a more runnable repro case is needed.