### PR TITLE
ci: ignore bincode being unmaintained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,11 @@ ignore = [
 
     # from derivative via cosmic_undo_2
     { id = "RUSTSEC-2024-0388" },
+
+    # bincode 1.3.3 via syntect - maintainers ceased development
+    # maintainers consider 1.3.3 complete that is not in need of any updates
+    # syntect is planning to remove it and move to wincode (or something else)
+    { id = "RUSTSEC-2025-0141" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -92,9 +97,6 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
-    "Unicode-DFS-2016",
-    "BSD-3-Clause",
-    "BSD-2-Clause",
     "Zlib",
     "Unicode-3.0",
     #"Apache-2.0 WITH LLVM-exception",
@@ -204,7 +206,6 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    { name = "bitflags" },
     { name = "syn" },
 
     # These three are from swash being on an older version of skrifa than harfrust and ourselves


### PR DESCRIPTION
We already are ignoring "RUSTSEC-2024-0320", we should ignore "RUSTSEC-2025-0141" too.