### PR TITLE
Implement `layout_runs` for `BufferLine`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -108,7 +108,17 @@ pub struct LayoutRunIter<'b> {
 }
 
 impl<'b> LayoutRunIter<'b> {
-    pub const fn new(
+    pub const fn new(buffer: &'b Buffer) -> Self {
+        Self::from_lines(
+            buffer.lines.as_slice(),
+            buffer.height_opt,
+            buffer.metrics.line_height,
+            buffer.scroll.vertical,
+            buffer.scroll.line,
+        )
+    }
+
+    pub const fn from_lines(
         lines: &'b [BufferLine],
         height_opt: Option<f32>,
         line_height: f32,
@@ -935,13 +945,7 @@ impl Buffer {
 
     /// Get the visible layout runs for rendering and other tasks
     pub fn layout_runs(&self) -> LayoutRunIter<'_> {
-        LayoutRunIter::new(
-            &self.lines,
-            self.height_opt,
-            self.metrics.line_height,
-            self.scroll.vertical,
-            self.scroll.line,
-        )
+        LayoutRunIter::new(self)
     }
 
     /// Convert x, y position to Cursor (hit detection)

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -279,7 +279,7 @@ impl BufferLine {
 
     /// Get the visible layout runs for rendering and other tasks
     pub fn layout_runs(&self, height_opt: Option<f32>, line_height: f32) -> LayoutRunIter<'_> {
-        LayoutRunIter::new(core::slice::from_ref(self), height_opt, line_height, 0.0, 0)
+        LayoutRunIter::from_lines(core::slice::from_ref(self), height_opt, line_height, 0.0, 0)
     }
 
     /// Get line metadata. This will be None if [`BufferLine::set_metadata`] has not been called


### PR DESCRIPTION
And refactors `LayoutRunIter` so that it can be returned both by `Buffer` and `BufferLine`.