### PR TITLE
fix: use unicode-width to get the correct width of monospace glyphs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sys-locale = { version = "0.3.2", optional = true }
 unicode-linebreak = "0.1.5"
 unicode-script = "0.5.8"
 unicode-segmentation = "1.12.0"
+unicode-width = "0.2.2"
 
 [dependencies.swash]
 version = "0.2.6"

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -259,7 +259,8 @@ impl BufferLine {
                 .layout_opt
                 .take_unused()
                 .unwrap_or_else(|| Vec::with_capacity(1));
-            let shape = self.shape(font_system, tab_width);
+            self.shape(font_system, tab_width);
+            let shape = self.shape_opt.get().expect("shape not found");
             shape.layout_to_buffer(
                 &mut font_system.shape_buffer,
                 font_size,
@@ -270,6 +271,7 @@ impl BufferLine {
                 &mut layout,
                 match_mono_width,
                 hinting,
+                &self.text,
             );
             self.layout_opt.set_used(layout);
         }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
+use unicode_width::UnicodeWidthChar;
 
 use alloc::collections::VecDeque;
 use core::cmp::{max, min};
@@ -1588,6 +1589,7 @@ impl ShapeLine {
             &mut lines,
             match_mono_width,
             hinting,
+            "",
         );
         lines
     }
@@ -2287,6 +2289,7 @@ impl ShapeLine {
         layout_lines: &mut Vec<LayoutLine>,
         match_mono_width: Option<f32>,
         hinting: Hinting,
+        line_text: &str,
     ) {
         // For each visual line a list of  (span index,  and range of words in that span)
         // Note that a BiDi visual line could have multiple spans or parts of them
@@ -2903,9 +2906,14 @@ impl ShapeLine {
                                     0.0
                                 },
                             );
-                            if let Some(match_em_width) = match_mono_em_width {
-                                // Round to nearest monospace width
-                                x_advance = ((x_advance / match_em_width).round()) * match_em_width;
+                            if let Some(mono_width) = match_mono_width {
+                                let cells = line_text
+                                    .get(glyph.start..)
+                                    .and_then(|s| s.chars().next())
+                                    .and_then(|c| c.width())
+                                    .map(|ucw| ucw as f32)
+                                    .unwrap_or_else(|| (x_advance / mono_width).round());
+                                x_advance = cells * mono_width;
                             }
                             if hinting == Hinting::Enabled {
                                 x_advance = x_advance.round();


### PR DESCRIPTION
Supersedes https://github.com/pop-os/cosmic-text/pull/503

Alacritty uses unicode-width to create the grid it produces in cosmic-term. Currently we pass the text to cosmic-text and it lays it out using x-advance which for some glyphs it creates inconsistencies. The previous attempt was to round/ceil to a whole cell number, but turns out it's not that simple, the unicode-width crate is a better reference. So let's use that.

In this PR, we use the same library to see how many cells a monospace glyph should take. 

This doesn't (shouldn't) affect normal buffers (they don't have match_mono_width set), and for monospace buffer should only add a couple of nanoseconds. Most terminal buffers are just ASCII characters so they're short-circuited, and for the rest it's a quick static lookup, shouldn't add more than a couple of nanoseconds (compared to ms for shaping).

___

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

