### PR TITLE
fix: Remove assert_eq! from BiDi ShapeLine for avoid crash

### DIFF
--- a/examples/editor-test/src/main.rs
+++ b/examples/editor-test/src/main.rs
@@ -162,7 +162,7 @@ fn main() {
 
     let mut wrong = 0;
     editor.with_buffer(|buffer| {
-        for (line_i, line) in text.lines().enumerate() {
+        for (line_i, line) in BidiParagraphs::new(&text).enumerate() {
             let buffer_line = &buffer.lines[line_i];
             if buffer_line.text() != line {
                 log::error!("line {}: {:?} != {:?}", line_i, buffer_line.text(), line);

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1300,12 +1300,11 @@ impl ShapeLine {
         }
     }
 
-    /// Shape a line into a set of spans, using a scratch buffer. If [`unicode_bidi::BidiInfo`]
-    /// detects multiple paragraphs, they will be joined.
+    /// Shape a line into a set of spans, using a scratch buffer.
     ///
-    /// # Panics
-    ///
-    /// Will panic if `line` contains multiple paragraphs that do not have matching direction
+    /// When [`unicode_bidi::BidiInfo`] splits `line` into multiple paragraphs (on
+    /// any `BidiClass::B` separator, e.g. LF, CR, FS, NEL, PS), the whole line is
+    /// laid out in the first paragraph's base direction.
     pub fn new(
         font_system: &mut FontSystem,
         line: &str,
@@ -1321,10 +1320,6 @@ impl ShapeLine {
     /// See [`Self::new`].
     ///
     /// Reuses as much of the pre-existing internal allocations as possible.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if `line` contains multiple paragraphs that do not have matching direction
     pub fn build(
         &mut self,
         font_system: &mut FontSystem,
@@ -1355,9 +1350,6 @@ impl ShapeLine {
         log::trace!("Line {}: '{}'", if rtl { "RTL" } else { "LTR" }, line);
 
         for para_info in &bidi.paragraphs {
-            let line_rtl = para_info.level.is_rtl();
-            assert_eq!(line_rtl, rtl);
-
             let line_range = para_info.range.clone();
             let levels = Self::adjust_levels(&unicode_bidi::Paragraph::new(&bidi, para_info));
 
@@ -1381,7 +1373,7 @@ impl ShapeLine {
                         line,
                         attrs_list,
                         start..i,
-                        line_rtl,
+                        rtl,
                         run_level,
                         shaping,
                     );
@@ -1396,7 +1388,7 @@ impl ShapeLine {
                 line,
                 attrs_list,
                 start..line_range.end,
-                line_rtl,
+                rtl,
                 run_level,
                 shaping,
             );

--- a/tests/shaping_and_rendering.rs
+++ b/tests/shaping_and_rendering.rs
@@ -142,3 +142,32 @@ fn test_ligature_segmentation() {
         shape.spans[0].words.len()
     );
 }
+
+#[test]
+fn test_mixed_direction_paragraphs_do_not_panic() {
+    use cosmic_text::{AttrsList, FontSystem, ShapeLine, Shaping};
+
+    let mut font_system =
+        FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/Inter-Regular.ttf").unwrap());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/NotoSansHebrew.ttf").unwrap());
+
+    // Latin 'A' and Hebrew Aleph separated by each BidiClass::B code point, including
+    // PS (U+2029) and the ASCII FS (U+001C), to cover more than just newlines.
+    for sep in [
+        '\u{000A}', '\u{000D}', '\u{001C}', '\u{001D}', '\u{001E}', '\u{0085}', '\u{2029}',
+    ] {
+        let line = format!("A{sep}\u{05D0}");
+        ShapeLine::new(
+            &mut font_system,
+            &line,
+            &AttrsList::new(&Attrs::new()),
+            Shaping::Advanced,
+            8,
+        );
+    }
+}


### PR DESCRIPTION
Cosmic-text can crash when certain characters show up in the editor view.

Error message:
```
thread 'main' panicked at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cosmic-text-0.19.0/src/shape.rs:1359:13:
assertion `left == right` failed
  left: false
 right: true
```

Reproduce steps (commit `c24886c2471e5606587c46090cd25dbbf209186b`):
```bash
printf 'A\034\327\220\n' > /tmp/bidi.txt
./editor-test.sh /tmp/bidi.txt
```
As I understand it, the assert expects all paragraphs in a line to have the same direction. 
But for arbitrary text that's not always true, a line can split into paragraphs with different directions, and then it crashes on normal input.

And it seems this direction isn't really needed for correctness: the character order comes from the BiDi levels themselves, while the line direction is more for alignment and the ellipsis. 
So I just removed the assert and shape the line by its base direction. No more panic, and normal lines look the same as before.

- [ ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

