### PR TITLE
chore: bump skrifa + harfrust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bitflags = "2.10.0"
 core_maths = { version = "0.1.1", optional = true }
 cosmic_undo_2 = { version = "0.2.0", optional = true }
 fontdb = { version = "0.23", default-features = false }
-harfrust = { version = "0.5.0", default-features = false }
+harfrust = { version = "0.8.4", default-features = false }
 hashbrown = { version = "0.17", optional = true, default-features = false }
 libm = { version = "0.2.16", optional = true }
 linebender_resource_handle = { version = "0.1.1", default-features = false }
@@ -23,7 +23,7 @@ modit = { version = "0.1.5", optional = true }
 rangemap = "1.7.1"
 rustc-hash = { version = "2.1.1", default-features = false }
 self_cell = "1.2.2"
-skrifa = { version = "0.40.0", default-features = false }
+skrifa = { version = "0.42.0", default-features = false }
 smol_str = { version = "0.3.2", default-features = false }
 syntect = { version = "5.3.0", optional = true }
 sys-locale = { version = "0.3.2", optional = true }
@@ -46,7 +46,7 @@ features = ["hardcoded-data"]
 default = ["std", "swash", "fontconfig"]
 fontconfig = ["fontdb/fontconfig", "std"]
 monospace_fallback = []
-no_std = ["hashbrown", "dep:libm", "skrifa/libm", "core_maths", "swash?/libm"]
+no_std = ["hashbrown", "dep:libm", "skrifa/libm", "core_maths", "swash?/libm", "harfrust/libm"]
 peniko = []
 shape-run-cache = []
 std = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bitflags = "2.10.0"
 core_maths = { version = "0.1.1", optional = true }
 cosmic_undo_2 = { version = "0.2.0", optional = true }
 fontdb = { version = "0.23", default-features = false }
-harfrust = { version = "0.8.4", default-features = false }
+harfrust = { version = "0.12.0", default-features = false }
 hashbrown = { version = "0.17", optional = true, default-features = false }
 libm = { version = "0.2.16", optional = true }
 linebender_resource_handle = { version = "0.1.1", default-features = false }
@@ -23,7 +23,7 @@ modit = { version = "0.1.5", optional = true }
 rangemap = "1.7.1"
 rustc-hash = { version = "2.1.1", default-features = false }
 self_cell = "1.2.2"
-skrifa = { version = "0.42.0", default-features = false }
+skrifa = { version = "0.44.0", default-features = false }
 smol_str = { version = "0.3.2", default-features = false }
 syntect = { version = "5.3.0", optional = true }
 sys-locale = { version = "0.3.2", optional = true }
@@ -32,7 +32,7 @@ unicode-script = "0.5.8"
 unicode-segmentation = "1.12.0"
 
 [dependencies.swash]
-version = "0.2.6"
+version = "0.2.10"
 default-features = false
 features = ["render", "scale"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ modit = { version = "0.1.5", optional = true }
 rangemap = "1.7.1"
 rustc-hash = { version = "2.1.1", default-features = false }
 self_cell = "1.2.2"
-skrifa = { version = "0.44.0", default-features = false }
+skrifa = { version = ">= 0.40, <= 0.44", default-features = false }
 smol_str = { version = "0.3.2", default-features = false }
 syntect = { version = "5.3.0", optional = true }
 sys-locale = { version = "0.3.2", optional = true }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -220,9 +220,12 @@ fn shape_fallback(
         }
     };
 
-    let glyph_buffer = font
-        .shaper()
-        .shape_with_plan(shape_plan, buffer, &rb_font_features);
+    let glyph_buffer = font.shaper().shape(
+        buffer,
+        harfrust::ShapeOptions::new()
+            .plan(Some(shape_plan))
+            .features(&rb_font_features),
+    );
     let glyph_infos = glyph_buffer.glyph_infos();
     let glyph_positions = glyph_buffer.glyph_positions();
 


### PR DESCRIPTION
This makes the default build's dep graph unify on a single read-fonts 0.39.x + single version of skrifa.

### Before
```
~/b/cosmic-text (main) $ git rev-parse HEAD
c24886c2471e5606587c46090cd25dbbf209186b
~/b/cosmic-text (main) $ cargo build -q
~/b/cosmic-text (main) $ cargo tree -d -e normal
read-fonts v0.37.0
├── harfrust v0.5.2
│   └── cosmic-text v0.19.0 (/Users/akx/build/cosmic-text)
└── skrifa v0.40.0
    └── cosmic-text v0.19.0 (/Users/akx/build/cosmic-text)
read-fonts v0.39.2
└── skrifa v0.42.1
    └── swash v0.2.9
        └── cosmic-text v0.19.0 (/Users/akx/build/cosmic-text)
skrifa v0.40.0 (*)
skrifa v0.42.1 (*)
```
### After
```
~/b/cosmic-text (skrifa-042) $ cargo build -q
~/b/cosmic-text (skrifa-042) $ cargo tree -d -e normal
warning: nothing to print.
```

harfrust's [`shape_with_plan` had become private in 0.8.0](https://github.com/harfbuzz/harfrust/blob/c8494f2dda3b5cfe57205826cdc0c089a060babc/CHANGELOG.md?plain=1#L64-L73), so change that use.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
  - `cargo test` passes, and an upstream app using this code seems to work as before. 
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

