### PR TITLE
feat: option to set the default base direction for the buffer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -11,9 +11,9 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{
     render_decoration, Affinity, Align, Attrs, AttrsList, BidiParagraphs, BorrowedWithFontSystem,
-    BufferLine, Color, Cursor, DecorationSpan, Ellipsize, FontSystem, Hinting, LayoutCursor,
-    LayoutGlyph, LayoutLine, LineEnding, LineIter, Motion, Renderer, Scroll, ShapeLine, Shaping,
-    Wrap,
+    BufferLine, Color, Cursor, DecorationSpan, Direction, Ellipsize, FontSystem, Hinting,
+    LayoutCursor, LayoutGlyph, LayoutLine, LineEnding, LineIter, Motion, Renderer, Scroll,
+    ShapeLine, Shaping, Wrap,
 };
 
 bitflags::bitflags! {
@@ -28,6 +28,8 @@ bitflags::bitflags! {
         const TEXT_SET  = 0b0100;
         /// Scroll position changed — visible region may have shifted to unshaped lines
         const SCROLL    = 0b1000;
+        /// Base direction changed, reshape every line (some characters like '(' are shaped differently based on direction)
+        const DIRECTION = 0b1_0000;
     }
 }
 
@@ -345,6 +347,7 @@ pub struct Buffer {
     monospace_width: Option<f32>,
     tab_width: u16,
     hinting: Hinting,
+    direction: Direction,
     /// Dirty flags tracking which properties changed since last layout
     dirty: DirtyFlags,
 }
@@ -363,6 +366,7 @@ impl Clone for Buffer {
             monospace_width: self.monospace_width,
             tab_width: self.tab_width,
             hinting: self.hinting,
+            direction: self.direction,
             dirty: self.dirty,
         }
     }
@@ -394,6 +398,7 @@ impl Buffer {
             monospace_width: None,
             tab_width: 8,
             hinting: Hinting::default(),
+            direction: Direction::default(),
             dirty: DirtyFlags::empty(),
         }
     }
@@ -437,7 +442,13 @@ impl Buffer {
         if dirty.contains(DirtyFlags::TEXT_SET) {
             // Lines were replaced — already fresh, no cache to invalidate.
         } else {
-            if dirty.contains(DirtyFlags::TAB_SHAPE) {
+            if dirty.contains(DirtyFlags::DIRECTION) {
+                for line in &mut self.lines {
+                    if line.shape_opt().is_some() {
+                        line.reset_shaping();
+                    }
+                }
+            } else if dirty.contains(DirtyFlags::TAB_SHAPE) {
                 for line in &mut self.lines {
                     if line.shape_opt().is_some() && line.text().contains('\t') {
                         line.reset_shaping();
@@ -694,7 +705,7 @@ impl Buffer {
         line_i: usize,
     ) -> Option<&ShapeLine> {
         let line = self.lines.get_mut(line_i)?;
-        Some(line.shape(font_system, self.tab_width))
+        Some(line.shape(font_system, self.tab_width, self.direction))
     }
 
     /// Lay out the provided line index and return the result
@@ -713,6 +724,7 @@ impl Buffer {
             self.monospace_width,
             self.tab_width,
             self.hinting,
+            self.direction,
         ))
     }
 
@@ -805,6 +817,26 @@ impl Buffer {
         if tab_width != self.tab_width {
             self.tab_width = tab_width;
             self.dirty |= DirtyFlags::TAB_SHAPE | DirtyFlags::RELAYOUT;
+            self.redraw = true;
+        }
+    }
+
+    /// Get the current base [`Direction`].
+    pub const fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    /// Set the base [`Direction`] used when shaping text.
+    ///
+    /// [`Direction::Auto`] (the default) detects each paragraph's base direction
+    /// from its content. [`Direction::LeftToRight`] and [`Direction::RightToLeft`]
+    /// force it for the whole buffer; use them when you know the direction from
+    /// context such as the UI locale rather than from the text.
+    pub fn set_direction(&mut self, direction: Direction) {
+        if direction != self.direction {
+            self.direction = direction;
+            // DIRECTION reshapes every line, which resets layout as a side effect.
+            self.dirty |= DirtyFlags::DIRECTION;
             self.redraw = true;
         }
     }
@@ -1682,6 +1714,11 @@ impl BorrowedWithFontSystem<'_, Buffer> {
     /// Set the current [`Wrap`].
     pub fn set_wrap(&mut self, wrap: Wrap) {
         self.inner.set_wrap(wrap);
+    }
+
+    /// Set the base [`Direction`] used when shaping text.
+    pub fn set_direction(&mut self, direction: Direction) {
+        self.inner.set_direction(direction);
     }
 
     /// Set the current [`Ellipsize`].

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -5,8 +5,8 @@ use alloc::{string::String, vec::Vec};
 use core::mem;
 
 use crate::{
-    Align, Attrs, AttrsList, Cached, Ellipsize, FontSystem, Hinting, LayoutLine, LayoutRunIter,
-    LineEnding, ShapeLine, Shaping, Wrap,
+    Align, Attrs, AttrsList, Cached, Direction, Ellipsize, FontSystem, Hinting, LayoutLine,
+    LayoutRunIter, LineEnding, ShapeLine, Shaping, Wrap,
 };
 
 /// A line (or paragraph) of text that is shaped and laid out
@@ -212,7 +212,12 @@ impl BufferLine {
 
     /// Shape line, will cache results
     #[allow(clippy::missing_panics_doc)]
-    pub fn shape(&mut self, font_system: &mut FontSystem, tab_width: u16) -> &ShapeLine {
+    pub fn shape(
+        &mut self,
+        font_system: &mut FontSystem,
+        tab_width: u16,
+        direction: Direction,
+    ) -> &ShapeLine {
         if self.shape_opt.is_unused() {
             let mut line = self
                 .shape_opt
@@ -224,6 +229,7 @@ impl BufferLine {
                 &self.attrs_list,
                 self.shaping,
                 tab_width,
+                direction,
             );
             self.shape_opt.set_used(line);
             self.layout_opt.set_unused();
@@ -252,6 +258,7 @@ impl BufferLine {
         match_mono_width: Option<f32>,
         tab_width: u16,
         hinting: Hinting,
+        direction: Direction,
     ) -> &[LayoutLine] {
         if self.layout_opt.is_unused() {
             let align = self.align;
@@ -259,7 +266,7 @@ impl BufferLine {
                 .layout_opt
                 .take_unused()
                 .unwrap_or_else(|| Vec::with_capacity(1));
-            let shape = self.shape(font_system, tab_width);
+            let shape = self.shape(font_system, tab_width, direction);
             shape.layout_to_buffer(
                 &mut font_system.shape_buffer,
                 font_size,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -81,6 +81,30 @@ impl Shaping {
     }
 }
 
+/// The base direction (paragraph level) used when shaping text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Direction {
+    /// Detect each paragraph's base direction from its first strong character.
+    #[default]
+    Auto,
+    /// Force a left-to-right base direction for all text.
+    LeftToRight,
+    /// Force a right-to-left base direction for all text.
+    RightToLeft,
+}
+
+impl Direction {
+    /// The base paragraph level to hand to the bidi algorithm, or `None` to let
+    /// it auto-detect the level from the text.
+    fn bidi_level(self) -> Option<unicode_bidi::Level> {
+        match self {
+            Self::Auto => None,
+            Self::LeftToRight => Some(unicode_bidi::Level::ltr()),
+            Self::RightToLeft => Some(unicode_bidi::Level::rtl()),
+        }
+    }
+}
+
 const NUM_SHAPE_PLANS: usize = 6;
 
 /// A set of buffers containing allocations for shaped text.
@@ -1312,9 +1336,10 @@ impl ShapeLine {
         attrs_list: &AttrsList,
         shaping: Shaping,
         tab_width: u16,
+        direction: Direction,
     ) -> Self {
         let mut empty = Self::empty();
-        empty.build(font_system, line, attrs_list, shaping, tab_width);
+        empty.build(font_system, line, attrs_list, shaping, tab_width, direction);
         empty
     }
 
@@ -1332,6 +1357,7 @@ impl ShapeLine {
         attrs_list: &AttrsList,
         shaping: Shaping,
         tab_width: u16,
+        direction: Direction,
     ) {
         // Clear stale ellipsis span so it gets recomputed with the current attrs.
         // Without this, reusing a ShapeLine from a previous text (via Cached::Unused)
@@ -1345,9 +1371,10 @@ impl ShapeLine {
         cached_spans.clear();
         cached_spans.extend(spans.drain(..).rev());
 
-        let bidi = unicode_bidi::BidiInfo::new(line, None);
+        let bidi = unicode_bidi::BidiInfo::new(line, direction.bidi_level());
         let rtl = if bidi.paragraphs.is_empty() {
-            false
+            // No strong content to detect from, go with default base direction if it's set
+            direction == Direction::RightToLeft
         } else {
             bidi.paragraphs[0].level.is_rtl()
         };

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1969,9 +1969,15 @@ impl ShapeLine {
                 } else {
                     (WordGlyphPos::ZERO, WordGlyphPos::new(span.words.len(), 0))
                 }
-            } else if span_index == start.span {
+            } else if span_index == start.span && (start.word, start.glyph) != (0, 0) {
+                // Continuation of an incongruent (reversed) span after a wrap:
+                // this visual line holds the logically-leading words [0, start).
                 (WordGlyphPos::ZERO, start.word_glyph_pos())
             } else {
+                // No continuation offset, so the whole incongruent span belongs to
+                // this line. Without this, a fully-RTL span under a forced-LTR base
+                // direction (start == 0) would collapse to an empty range and drop
+                // all of its glyphs.
                 (WordGlyphPos::ZERO, WordGlyphPos::new(span.words.len(), 0))
             };
 

--- a/tests/direction.rs
+++ b/tests/direction.rs
@@ -1,0 +1,86 @@
+use cosmic_text::{fontdb, Attrs, Buffer, Direction, FontSystem, Metrics, Shaping, Wrap};
+
+fn font_system() -> FontSystem {
+    let mut font_system =
+        FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/Inter-Regular.ttf").unwrap());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/NotoSansArabic.ttf").unwrap());
+    font_system
+}
+
+fn first_run_rtl(buffer: &Buffer) -> bool {
+    buffer
+        .layout_runs()
+        .next()
+        .expect("expected at least one layout run")
+        .rtl
+}
+
+fn make_buffer(font_system: &mut FontSystem, text: &str, direction: Direction) -> Buffer {
+    let mut buffer = Buffer::new(font_system, Metrics::new(14.0, 20.0));
+    buffer.set_wrap(Wrap::None);
+    buffer.set_direction(direction);
+    buffer.set_text(text, &Attrs::new(), Shaping::Advanced, None);
+    buffer.shape_until_scroll(font_system, false);
+    buffer
+}
+
+#[test]
+fn auto_detects_per_paragraph() {
+    let mut font_system = font_system();
+    // Default Auto behavior: direction follows the first strong character.
+    let ltr = make_buffer(&mut font_system, "hello", Direction::Auto);
+    assert!(!first_run_rtl(&ltr));
+
+    let rtl = make_buffer(&mut font_system, "سلام", Direction::Auto);
+    assert!(first_run_rtl(&rtl));
+}
+
+#[test]
+fn forced_rtl_overrides_ltr_content() {
+    let mut font_system = font_system();
+    let buffer = make_buffer(&mut font_system, "hello", Direction::RightToLeft);
+    assert!(first_run_rtl(&buffer),);
+}
+
+#[test]
+fn forced_ltr_overrides_rtl_content() {
+    let mut font_system = font_system();
+    let buffer = make_buffer(&mut font_system, "سلام", Direction::LeftToRight);
+    assert!(!first_run_rtl(&buffer),);
+}
+
+#[test]
+fn force_ltr_overrides_first_strong_rtl() {
+    let mut font_system = font_system();
+    let buffer = make_buffer(&mut font_system, "   سلام", Direction::LeftToRight);
+    assert!(!first_run_rtl(&buffer));
+}
+
+#[test]
+fn force_ltr_overrides_weak() {
+    let mut font_system = font_system();
+    let mut buffer = make_buffer(&mut font_system, "   ()", Direction::LeftToRight);
+    assert!(!first_run_rtl(&buffer));
+    buffer.set_direction(Direction::RightToLeft);
+    buffer.shape_until_scroll(&mut font_system, false);
+    assert!(first_run_rtl(&buffer),);
+}
+
+#[test]
+fn changing_direction_reshapes_cached_lines() {
+    let mut font_system = font_system();
+    let mut buffer = Buffer::new(&mut font_system, Metrics::new(14.0, 20.0));
+    buffer.set_text("hello", &Attrs::new(), Shaping::Advanced, None);
+    buffer.shape_until_scroll(&mut font_system, false);
+    assert!(!first_run_rtl(&buffer));
+
+    // Switching direction must invalidate the already-shaped line.
+    buffer.set_direction(Direction::RightToLeft);
+    buffer.shape_until_scroll(&mut font_system, false);
+    assert!(first_run_rtl(&buffer));
+}

--- a/tests/direction.rs
+++ b/tests/direction.rs
@@ -55,6 +55,22 @@ fn forced_ltr_overrides_rtl_content() {
 }
 
 #[test]
+fn forced_ltr_keeps_rtl_glyphs() {
+    // a line whose content is entirely RTL must still produce glyphs
+    // when the base direction is forced to LTR (incongruent span on the no-wrap path)
+    let mut font_system = font_system();
+    let buffer = make_buffer(&mut font_system, "سلام", Direction::LeftToRight);
+    let run = buffer
+        .layout_runs()
+        .next()
+        .expect("expected at least one layout run");
+    assert!(
+        !run.glyphs.is_empty(),
+        "forced-LTR RTL line produced no glyphs"
+    );
+}
+
+#[test]
 fn force_ltr_overrides_first_strong_rtl() {
     let mut font_system = font_system();
     let buffer = make_buffer(&mut font_system, "   سلام", Direction::LeftToRight);

--- a/tests/wrap_stability.rs
+++ b/tests/wrap_stability.rs
@@ -1,6 +1,6 @@
 use cosmic_text::{
-    fontdb, Align, Attrs, AttrsList, BidiParagraphs, Buffer, Family, FontSystem, Hinting,
-    LayoutLine, Metrics, ShapeLine, Shaping, Weight, Wrap,
+    fontdb, Align, Attrs, AttrsList, BidiParagraphs, Buffer, Direction, Family, FontSystem,
+    Hinting, LayoutLine, Metrics, ShapeLine, Shaping, Weight, Wrap,
 };
 
 // Test for https://github.com/pop-os/cosmic-text/issues/134
@@ -21,7 +21,14 @@ fn stable_wrap() {
     font_system.db_mut().load_font_data(font);
 
     let mut check_wrap = |text: &_, wrap, align_opt, start_width_opt| {
-        let line = ShapeLine::new(&mut font_system, text, &attrs, Shaping::Advanced, 8);
+        let line = ShapeLine::new(
+            &mut font_system,
+            text,
+            &attrs,
+            Shaping::Advanced,
+            8,
+            Direction::Auto,
+        );
 
         let layout_unbounded = line.layout(
             font_size,


### PR DESCRIPTION
Currently cosmic-text always detect the text direction. But in some cases (such as an IDE, or an editor with a set locale) you want the whole text to be layout in a specific direction.

This introduces a `set_direction` method on `buffer` to allow a default base direction.

All other libraries also provide this setting, for example `Pango` has `pango_context_set_base_dir()`.


NOTE: 
This is a breaking change for the following public methods: `Shapeline::new/build` and `Bufferline::shape/layout`.

Fixes https://github.com/pop-os/cosmic-text/issues/512

Auto (No alignment):
<img width="618" height="317" alt="image" src="https://github.com/user-attachments/assets/9e05cae6-398c-4cca-8f67-223ae392e618" />


Auto + Aligned Left
<img width="618" height="312" alt="image" src="https://github.com/user-attachments/assets/0e41ab78-343f-4681-a20c-1f2e8d5eb204" />


With LTR base direction (No alignement):
<img width="617" height="312" alt="image" src="https://github.com/user-attachments/assets/44d84551-63a4-4a65-93fe-70942131f90b" />


Note that the last line is still mirroring "=>" because those are neutral characters sitting between strong directional (RTL) characters. It doesn't happen in vscode:
<img width="312" height="132" alt="image" src="https://github.com/user-attachments/assets/e7ed2600-d0b4-45fe-a499-321021ef7d69" />
Because vscode isolates tokens. So the same thing happens if you comment out the code:
<img width="267" height="81" alt="image" src="https://github.com/user-attachments/assets/86ddc0f7-4764-4911-be7d-054bfc646e5b" />

Zed needs this feature (to set LTR on the whole buffer which fixes indentation) and also needs to wrap syntax tokens with `U+2068` (FSI) and `U+2069` (PDI).

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

