### PR TITLE
fix: honor a word's default-attrs tail in the ASCII fast path

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -847,11 +847,16 @@ impl ShapeWord {
 
         if is_simple_ascii && !word.is_empty() && {
             let attrs_start = attrs_list.get_span(word_range.start);
+            // The fast path shapes the whole word with `attrs_start`. Besides
+            // the explicit spans, an uncovered gap falls back to the defaults,
+            // so reject the fast path when those differ (e.g. a styled prefix
+            // with a default tail, otherwise shaped with the prefix's font).
             attrs_list.spans_iter().all(|(other_range, other_attrs)| {
                 word_range.end <= other_range.start
                     || other_range.end <= word_range.start
                     || attrs_start.compatible(&other_attrs.as_attrs())
-            })
+            }) && (attrs_list.spans.gaps(&word_range).next().is_none()
+                || attrs_start.compatible(&attrs_list.defaults()))
         } {
             shaping.run(
                 &mut glyphs,

--- a/tests/fast_path_default_gap.rs
+++ b/tests/fast_path_default_gap.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+
+use cosmic_text::{fontdb, Attrs, Buffer, Family, FontSystem, Metrics, Shaping};
+
+/// A word whose prefix carries an explicit (non-default) attribute span while
+/// the tail falls back to the default attrs must not be shaped entirely with
+/// the prefix's font. The ASCII fast path in `ShapeWord::build` only inspects
+/// the explicit spans, so the default tail is an uncovered gap that must still
+/// be checked before taking the fast path.
+///
+/// Repro: word "Hello", prefix "He" = Fira Mono (explicit span), tail "llo" =
+/// default (Inter, a gap). The tail must be shaped with Inter.
+#[test]
+fn fast_path_respects_default_tail_after_styled_prefix() {
+    let repo_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let fonts_path = PathBuf::from(&repo_dir).join("fonts");
+
+    // Empty db with only Inter and Fira Mono so font fallback is deterministic.
+    let mut db = fontdb::Database::new();
+    db.load_font_data(std::fs::read(fonts_path.join("Inter-Regular.ttf")).unwrap());
+    db.load_font_data(std::fs::read(fonts_path.join("FiraMono-Medium.ttf")).unwrap());
+    let mut font_system = FontSystem::new_with_locale_and_db("en-US".into(), db);
+
+    // Default = Inter, prefix = Fira Mono. Two distinct physical faces so a
+    // mis-shaped tail shows up as a font_id mismatch, independent of weight.
+    let default_attrs = Attrs::new().family(Family::Name("Inter"));
+    let prefix_attrs = Attrs::new().family(Family::Name("Fira Mono"));
+
+    let metrics = Metrics::new(16.0, 20.0);
+    let mut buffer = Buffer::new(&mut font_system, metrics);
+
+    let glyphs: Vec<(usize, fontdb::ID)>;
+    {
+        let mut buffer = buffer.borrow_with(&mut font_system);
+        buffer.set_size(Some(300.0), Some(100.0));
+        // `set_rich_text` only records a span when its attrs differ from the
+        // list defaults, so passing `default_attrs` for "llo" leaves an
+        // uncovered gap at bytes 2..5 (Inter) rather than an explicit span —
+        // exactly the default-attrs tail the fast-path gap check guards.
+        buffer.set_rich_text(
+            [("He", prefix_attrs), ("llo", default_attrs.clone())],
+            &default_attrs,
+            Shaping::Advanced,
+            None,
+        );
+        buffer.shape_until_scroll(true);
+        glyphs = buffer
+            .layout_runs()
+            .flat_map(|run| run.glyphs.iter().map(|g| (g.start, g.font_id)))
+            .collect();
+    }
+
+    assert!(!glyphs.is_empty(), "no glyphs were produced");
+
+    // "He" is 2 ASCII bytes (offsets 0..2); "llo" follows at 2..5.
+    // `LayoutGlyph::start` is the byte offset of the cluster in the line.
+    for (start, id) in &glyphs {
+        let face = font_system.db().face(*id).unwrap();
+        let family = &face.families[0].0;
+        if *start < 2 {
+            assert!(
+                family.contains("Fira"),
+                "prefix glyph at {start} used \"{family}\", expected Fira Mono"
+            );
+        } else {
+            assert!(
+                family.contains("Inter"),
+                "tail glyph at {start} shaped as \"{family}\", expected Inter (default tail leaked the prefix font)"
+            );
+        }
+    }
+}


### PR DESCRIPTION
The ASCII fast path in `ShapeWord::build` (added in #407) is guarded since #445/#447 by requiring every attribute span that intersects the word to be compatible with the word-start attrs. That check only iterates the **explicit** spans returned by `AttrsList::spans_iter`, so it never accounts for positions that fall back to the list's default attrs.

## Cause

When a non-default span covers the start of an ASCII word and the rest of the word resolves to incompatible defaults, the guard still passes and the whole word is shaped with the prefix's font. A common trigger is a styled prefix with an unstyled tail in a single word — e.g. a bold `hel` + default `lo`, as produced by "bionic reading" formatting — where `hello` is shaped entirely bold.

This is the residual case #447 did not cover: it compares the *explicit* spans against each other, but a default-attrs **gap** has no explicit span to compare.

## Fix

Reject the fast path when the word range contains any uncovered gap, unless the defaults are themselves compatible with the word-start attrs:

```rust
}) && (attrs_list.spans.gaps(&word_range).next().is_none()
    || attrs_start.compatible(&attrs_list.defaults()))
```

This restores the guard's full invariant — *the fast path is valid iff every position in the word shapes to a font compatible with the word start* — covering both explicit spans and default gaps. It keeps the fast path for the common all-default word and for fully covered uniform words, and routes only the affected words to the existing per-grapheme path, which already shapes each compatible sub-run correctly.

## Before / after
<img width="560" height="792" alt="cosmic-text-pr-before-after" src="https://github.com/user-attachments/assets/377e4fe7-090d-4e77-90b0-c1911e65ba7b" />

The same words rendered through cosmic-text (`SwashCache` + `tiny-skia`), before vs. after — only the styled prefix should be bold; the default tail must stay normal. Controls (`Worldwide`, `Building`) are unchanged.

## Test

`tests/fast_path_default_gap.rs` shapes one ASCII word (`Hello`) with a styled prefix (`He` = Fira Mono, an explicit span) and a default tail (`llo` = Inter, a gap), then asserts the tail glyphs resolve to Inter. It **fails on `main`** (the tail is shaped as Fira Mono) and passes with this change.

## Verified downstream

Built cosmic-term against this patch and confirmed it fixes pop-os/cosmic-term#791 — a bionic-style `\e[1mhel\e[0mlo` renders with only the prefix bold instead of the whole word.

---

AI disclosure: the analysis, code, and test in this change were produced with AI assistance (Claude Code).

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.