### PR TITLE
chore(cargo-deny): ignore ttf-parser unmaintained advisory for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -80,6 +80,11 @@ ignore = [
     # maintainers consider 1.3.3 complete that is not in need of any updates
     # syntect is planning to remove it and move to wincode (or something else)
     { id = "RUSTSEC-2025-0141" },
+
+    # ttf-parser 0.25.1+ unmaintained, skrifa's parser is an alternative.
+    # this crate uses ttf-parser via fontdb, which has last been updated
+    # in October 2024.
+    { id = "RUSTSEC-2026-0192" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - No LLMs here.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
  - `cargo deny check` passes now. 
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

I noticed CI was red on #513 because of this.

<del>As noted in the comments, `fontdb`, which is the sole reason `ttf-parser` is required here, has last seen a release in 2024, so it will probably need to be updated or forked to truly get rid of the unmaintained `ttf-parser`.</del>

According to https://github.com/RazrFalcon/fontdb/issues/90#issuecomment-5011040203 there may be a ttf-parser-less fontdb release soon. :)
