### PR TITLE
fix: honor cursor Affinity when resolving the caret position

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -146,9 +146,27 @@ impl LayoutRun<'_> {
     /// Find which glyph in this run contains `cursor`, returning
     /// `(glyph_index, pixel_offset_within_glyph)`, or `None` if the cursor
     /// is not on this run.
+    ///
+    /// At an exact glyph boundary the cursor's [`Affinity`] picks the side:
+    /// `Before` attaches to the glyph that *ends* at the index, `After` to the
+    /// glyph that *starts* there. The two positions only differ where runs of
+    /// opposite direction meet — in single-direction text they are the same x.
     pub fn cursor_glyph(&self, cursor: &Cursor) -> Option<(usize, f32)> {
         if cursor.line != self.line_i {
             return None;
+        }
+        // Honor Affinity::Before at exact glyph boundaries. hit() and the cursor
+        // motions set affinity, but resolving the position while ignoring it
+        // painted every boundary caret on the After side, so the caret teleported
+        // across a mixed line's direction seam regardless of how the cursor
+        // arrived. When no glyph ends at the index (index 0), fall through to the
+        // existing search below.
+        if cursor.affinity == Affinity::Before && cursor.index > 0 {
+            for (glyph_i, glyph) in self.glyphs.iter().enumerate() {
+                if cursor.index == glyph.end {
+                    return Some((glyph_i, glyph.w));
+                }
+            }
         }
         for (glyph_i, glyph) in self.glyphs.iter().enumerate() {
             if cursor.index == glyph.start {

--- a/tests/cursor.rs
+++ b/tests/cursor.rs
@@ -1,0 +1,87 @@
+use cosmic_text::{
+    fontdb, Affinity, Attrs, Buffer, Cursor, Direction, FontSystem, Metrics, Shaping, Wrap,
+};
+
+fn font_system() -> FontSystem {
+    let mut font_system =
+        FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/Inter-Regular.ttf").unwrap());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/NotoSansArabic.ttf").unwrap());
+    font_system
+}
+
+fn make_buffer(font_system: &mut FontSystem, text: &str, direction: Direction) -> Buffer {
+    let mut buffer = Buffer::new(font_system, Metrics::new(14.0, 20.0));
+    buffer.set_wrap(Wrap::None);
+    buffer.set_direction(direction);
+    buffer.set_text(text, &Attrs::new(), Shaping::Advanced, None);
+    buffer.shape_until_scroll(font_system, false);
+    buffer
+}
+
+#[test]
+fn affinity_picks_the_caret_side_at_a_direction_seam() {
+    // "abc" (LTR) then Arabic (RTL): logical index 3 is the seam between two
+    // runs of opposite direction, so the Before and After caret positions are
+    // different x coordinates. Affinity must pick the side the cursor arrived
+    // from: Before attaches to the glyph that ENDS at the index, After to the
+    // glyph that STARTS there.
+    let mut font_system = font_system();
+    let buffer = make_buffer(&mut font_system, "abcسلام", Direction::Auto);
+    let run = buffer
+        .layout_runs()
+        .next()
+        .expect("expected at least one layout run");
+
+    let seam = 3; // byte index: end of "abc", start of the Arabic run
+
+    let (before_glyph, _) = run
+        .cursor_glyph(&Cursor::new_with_affinity(0, seam, Affinity::Before))
+        .expect("Before cursor at the seam must resolve");
+    assert_eq!(
+        run.glyphs[before_glyph].end, seam,
+        "Affinity::Before must attach to the glyph that ends at the index"
+    );
+
+    let (after_glyph, _) = run
+        .cursor_glyph(&Cursor::new_with_affinity(0, seam, Affinity::After))
+        .expect("After cursor at the seam must resolve");
+    assert_eq!(
+        run.glyphs[after_glyph].start, seam,
+        "Affinity::After must attach to the glyph that starts at the index"
+    );
+
+    // The two sides are distinct glyphs at a direction seam (in
+    // single-direction text they would be the same x, and affinity is moot).
+    assert_ne!(before_glyph, after_glyph);
+}
+
+#[test]
+fn affinity_is_moot_inside_a_single_direction_run() {
+    // In plain LTR text, end-of-glyph-N and start-of-glyph-N+1 are the same x;
+    // both affinities must produce that same caret x.
+    let mut font_system = font_system();
+    let buffer = make_buffer(&mut font_system, "abcdef", Direction::Auto);
+    let run = buffer
+        .layout_runs()
+        .next()
+        .expect("expected at least one layout run");
+
+    let index = 3;
+    let x_of = |affinity| {
+        let (glyph_i, offset) = run
+            .cursor_glyph(&Cursor::new_with_affinity(0, index, affinity))
+            .expect("cursor must resolve");
+        run.glyphs[glyph_i].x + offset
+    };
+    let before_x = x_of(Affinity::Before);
+    let after_x = x_of(Affinity::After);
+    assert!(
+        (before_x - after_x).abs() < 0.5,
+        "affinity must not move the caret inside a single-direction run: before {before_x} vs after {after_x}"
+    );
+}


### PR DESCRIPTION
## The bug

`hit()` and the cursor motions set `Affinity::Before`/`After` carefully, but `LayoutRun::cursor_glyph` never reads it: at a boundary between runs of opposite direction the caret always resolves to the logical-after side. In an editor over a mixed bidi line the caret visually teleports across the direction seam regardless of which side the cursor arrived from — clicking at the end of the LTR half paints the caret in the middle of the RTL half (and vice versa).

## The fix

`Affinity::Before` now prefers the glyph that **ends** at the cursor index (returning its trailing edge), falling through to the existing start-of-glyph search when no glyph ends there (index 0). `Affinity::After` behavior is unchanged.

In single-direction text, end-of-glyph-N and start-of-glyph-N+1 are the same x, so this changes nothing outside mixed lines — the second test pins that.

## Tests

- `affinity_picks_the_caret_side_at_a_direction_seam` — "abc" + Arabic, cursor at the seam: fails before this change (`Before` resolved to the After-side glyph deep in the Arabic run), passes after.
- `affinity_is_moot_inside_a_single_direction_run` — both affinities agree in plain LTR text, before and after the change.

Found while building an RTL-first text stack on cosmic-text; part of a small series of RTL correctness fixes with #520 and #521.