### PR TITLE
fix: hit() before-line detection for aligned lines

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1199,7 +1199,12 @@ impl Buffer {
                 'hit: for (glyph_i, glyph) in run.glyphs.iter().enumerate() {
                     if first_glyph {
                         first_glyph = false;
-                        if (run.rtl && x > glyph.x) || (!run.rtl && x < 0.0) {
+                        // "Before the line" for LTR is left of the first glyph, not
+                        // left of x=0: under Align::Right/Center a short line starts at
+                        // glyph.x > 0, and the hardcoded 0.0 sent clicks in the leading
+                        // gap to the line END via the fall-through arm. glyphs[0].x is
+                        // the true minimum x by L2-reorder construction.
+                        if (run.rtl && x > glyph.x) || (!run.rtl && x < glyph.x) {
                             new_cursor_glyph = 0;
                             new_cursor_char = 0;
                         }

--- a/tests/hit.rs
+++ b/tests/hit.rs
@@ -1,0 +1,59 @@
+use cosmic_text::{fontdb, Align, Attrs, Buffer, FontSystem, Metrics, Shaping, Wrap};
+
+fn font_system() -> FontSystem {
+    let mut font_system =
+        FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/Inter-Regular.ttf").unwrap());
+    font_system
+}
+
+#[test]
+fn click_before_a_right_aligned_line_hits_its_start() {
+    // A short right-aligned line starts at glyphs[0].x > 0. A click in the
+    // leading gap (left of the text, but x >= 0) is "before the line" and must
+    // place the cursor at the line START. The old test was hardcoded `x < 0.0`,
+    // so such clicks fell through to the past-all-glyphs arm and landed at the
+    // line END instead.
+    let mut font_system = font_system();
+    let mut buffer = Buffer::new(&mut font_system, Metrics::new(14.0, 20.0));
+    buffer.set_size(Some(400.0), None);
+    buffer.set_wrap(Wrap::None);
+    buffer.set_text("hi", &Attrs::new(), Shaping::Advanced, None);
+    buffer.lines[0].set_align(Some(Align::Right));
+    buffer.shape_until_scroll(&mut font_system, false);
+
+    let run = buffer
+        .layout_runs()
+        .next()
+        .expect("expected at least one layout run");
+    let first_glyph_x = run.glyphs.first().expect("expected glyphs").x;
+    assert!(
+        first_glyph_x > 10.0,
+        "the right-aligned line must start well right of x=0 (got {first_glyph_x})"
+    );
+
+    let cursor = buffer
+        .hit(first_glyph_x / 2.0, 10.0)
+        .expect("expected a hit");
+    assert_eq!(
+        cursor.index, 0,
+        "a click in the leading gap of a right-aligned line must hit the line start"
+    );
+}
+
+#[test]
+fn click_before_a_flush_left_line_still_hits_its_start() {
+    // Guard for the flush-left case the old `x < 0.0` did handle: a click at
+    // negative x still resolves to the line start.
+    let mut font_system = font_system();
+    let mut buffer = Buffer::new(&mut font_system, Metrics::new(14.0, 20.0));
+    buffer.set_size(Some(400.0), None);
+    buffer.set_wrap(Wrap::None);
+    buffer.set_text("hi", &Attrs::new(), Shaping::Advanced, None);
+    buffer.shape_until_scroll(&mut font_system, false);
+
+    let cursor = buffer.hit(-5.0, 10.0).expect("expected a hit");
+    assert_eq!(cursor.index, 0);
+}


### PR DESCRIPTION
## The bug

The clicked-before-the-line test for LTR runs in `Buffer::hit` is hardcoded `x < 0.0`, which is only correct for flush-left layout. Under `Align::Right` or `Align::Center` a short line starts at `glyphs[0].x > 0`, so a click in the leading gap (left of the text, but at x ≥ 0) falls through to the past-all-glyphs arm — placing the cursor at the line **end** instead of the start. In an editor, clicking just left of a right-aligned line jumps the caret to the wrong side of the line.

## The fix

Compare against `glyphs[0].x` — the true visual start of the run by L2-reorder construction — instead of 0.0. The RTL arm already does the equivalent (`x > glyph.x`).

## Tests

- `click_before_a_right_aligned_line_hits_its_start` — fails before this change (the click landed at the line end), passes after.
- `click_before_a_flush_left_line_still_hits_its_start` — pins the negative-x case the old test did handle.