### PR TITLE
fix: fresh-line sentinel still aliases span 0 in width and overflow math

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1242,11 +1242,8 @@ struct SpanWordGlyphPos {
 }
 
 impl SpanWordGlyphPos {
-    const ZERO: Self = Self {
-        span: 0,
-        word: 0,
-        glyph: 0,
-    };
+    // NOTE: the old `ZERO` sentinel was removed; a fresh line (no resume point)
+    // now uses an unaliasable usize::MAX sentinel in `layout_spans` (see there).
     fn word_glyph_pos(&self) -> WordGlyphPos {
         WordGlyphPos {
             word: self.word,
@@ -1774,16 +1771,26 @@ impl ShapeLine {
 
         let mut total_w: f32 = 0.0;
 
-        let start = if let Some(s) = start_opt {
-            s
-        } else {
-            SpanWordGlyphPos::ZERO
-        };
+        // A fresh line (no resume point) must not alias span 0 / word 0: the old
+        // ZERO sentinel made every `== start.span` / `== start.word` "resumed
+        // span" arm fire on the FIRST span of a fresh line. The tail-commit arm
+        // was guarded individually, but the same aliasing still zeroes word 0's
+        // width through get_glyph_start_end (an incongruent fresh-line word
+        // measures 0, so ellipsis triggers too late and the line overflows) and
+        // truncates the overflow range_end to (0, 0). usize::MAX matches no real
+        // span/word, so every resume arm is uniformly dead on a fresh line;
+        // traversal still starts at span 0 via `traverse_from`.
+        let traverse_from = start_opt.map_or(0, |s| s.span);
+        let start = start_opt.unwrap_or(SpanWordGlyphPos {
+            span: usize::MAX,
+            word: usize::MAX,
+            glyph: 0,
+        });
 
         let span_indices: Vec<usize> = if matches!(direction, LayoutDirection::Forward) {
-            (start.span..spans.len()).collect()
+            (traverse_from..spans.len()).collect()
         } else {
-            (start.span..spans.len()).rev().collect()
+            (traverse_from..spans.len()).rev().collect()
         };
 
         'outer: for span_index in span_indices {
@@ -1858,7 +1865,11 @@ impl ShapeLine {
                                     starting_word_index,
                                     direction,
                                     congruent,
-                                    start.span,
+                                    // The traversal floor, not `start` itself: on a
+                                    // fresh line `start` is the unaliasable sentinel,
+                                    // while the Backward remaining-spans range needs
+                                    // the real lower bound (0 on a fresh line).
+                                    traverse_from,
                                     span_count,
                                     ellipsis_w,
                                 ) && total_w + word_range_width + word_width + ellipsis_w

--- a/tests/ellipsize_incongruent.rs
+++ b/tests/ellipsize_incongruent.rs
@@ -1,0 +1,61 @@
+use cosmic_text::{
+    fontdb, Attrs, Buffer, Direction, Ellipsize, EllipsizeHeightLimit, FontSystem, Metrics,
+    Shaping, Wrap,
+};
+
+fn font_system() -> FontSystem {
+    let mut font_system =
+        FontSystem::new_with_locale_and_db("en-US".into(), fontdb::Database::new());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/Inter-Regular.ttf").unwrap());
+    font_system
+        .db_mut()
+        .load_font_data(std::fs::read("fonts/NotoSansArabic.ttf").unwrap());
+    font_system
+}
+
+fn max_glyph_extent(buffer: &Buffer) -> f32 {
+    buffer
+        .layout_runs()
+        .flat_map(|run| run.glyphs.iter().map(|g| g.x + g.w).collect::<Vec<_>>())
+        .fold(0.0, f32::max)
+}
+
+#[test]
+fn ellipsis_respects_the_width_when_the_line_opens_incongruent() {
+    // Forced-LTR base with RTL-first content: the first span of the (fresh)
+    // line runs against the base direction. get_glyph_start_end must measure
+    // that word fully; if the fresh-line sentinel aliases span 0 / word 0, the
+    // opening word measures 0 wide, the overflow check believes more content
+    // fits than does, and the ellipsized line paints past the buffer width.
+    let mut font_system = font_system();
+
+    // First, the unconstrained extent of the full line.
+    let mut probe = Buffer::new(&mut font_system, Metrics::new(14.0, 20.0));
+    probe.set_wrap(Wrap::None);
+    probe.set_direction(Direction::LeftToRight);
+    probe.set_text("سلام hello world", &Attrs::new(), Shaping::Advanced, None);
+    probe.shape_until_scroll(&mut font_system, false);
+    let full_extent = max_glyph_extent(&probe);
+    assert!(full_extent > 0.0, "the probe line must produce glyphs");
+
+    // Now constrain to well under the full extent and ellipsize the end.
+    let width = full_extent * 0.6;
+    let mut buffer = Buffer::new(&mut font_system, Metrics::new(14.0, 20.0));
+    buffer.set_size(Some(width), None);
+    buffer.set_wrap(Wrap::None);
+    buffer.set_direction(Direction::LeftToRight);
+    buffer.set_ellipsize(Ellipsize::End(EllipsizeHeightLimit::Lines(1)));
+    buffer.set_text("سلام hello world", &Attrs::new(), Shaping::Advanced, None);
+    buffer.shape_until_scroll(&mut font_system, false);
+
+    let extent = max_glyph_extent(&buffer);
+    assert!(
+        extent <= width + 0.5,
+        "the ellipsized line must stay within the buffer width: extent {extent} > width {width}"
+    );
+
+    // And it must still paint something — ellipsizing is not dropping the line.
+    assert!(extent > 0.0, "the ellipsized line must produce glyphs");
+}


### PR DESCRIPTION
## The bug

Follow-up to 4fe1195e, which guarded the tail-commit arm of `layout_spans` against the fresh-line `SpanWordGlyphPos::ZERO` sentinel aliasing a genuine resume at span 0 — that fixed the dropped glyphs, but the same aliasing survives at the other `== start.span` / `== start.word` comparison sites:

- **Width undercount:** word 0 of an incongruent fresh-line span measures **0 wide** through `get_glyph_start_end` (the aliased `start` makes it return the empty glyph range `(0, start.glyph = 0)`). The overflow check then believes more content fits than does, and an ellipsized line paints past the buffer width. Reproduced in the new test: forced-LTR base + RTL-first content ("سلام hello world"), `Ellipsize::End`, width at 60% of the full extent → the rendered extent exceeds the width by ~25%.
- **Overflow range truncation:** the overflow arm's `range_end` (`if span_index == start.span && !congruent { start.word_glyph_pos() }`) truncates to `(0, 0)` on a fresh line.

## The fix

Replace the ZERO sentinel with `span/word = usize::MAX`, which matches no real span or word — every resume arm is uniformly dead on fresh lines instead of each site needing its own guard. Traversal still starts at span 0 via an explicit `traverse_from` floor, and `remaining_content_exceeds` receives that floor rather than the sentinel (its Backward remaining-spans range needs the real lower bound, 0 on a fresh line). The now-unused `ZERO` const is removed.

The 4fe1195e guard and its `forced_ltr_keeps_rtl_glyphs` test keep working unchanged (the guard now only ever sees genuine resumes).

## Tests

- `ellipsis_respects_the_width_when_the_line_opens_incongruent` — fails before this change (extent 76.9 vs width 61.3 in this environment), passes after.
- Full existing suite green, including the direction and draw tests.