### PR TITLE
chore: bump fontdb to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.89"
 bitflags = "2.10.0"
 core_maths = { version = "0.1.1", optional = true }
 cosmic_undo_2 = { version = "0.2.0", optional = true }
-fontdb = { version = "0.23", default-features = false }
+fontdb = { version = "0.24", default-features = false }
 harfrust = { version = "0.5.0", default-features = false }
 hashbrown = { version = "0.17", optional = true, default-features = false }
 libm = { version = "0.2.16", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -80,11 +80,6 @@ ignore = [
     # maintainers consider 1.3.3 complete that is not in need of any updates
     # syntect is planning to remove it and move to wincode (or something else)
     { id = "RUSTSEC-2025-0141" },
-
-    # ttf-parser 0.25.1+ unmaintained, skrifa's parser is an alternative.
-    # this crate uses ttf-parser via fontdb, which has last been updated
-    # in October 2024.
-    { id = "RUSTSEC-2026-0192" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/examples/editor-test/Cargo.toml
+++ b/examples/editor-test/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 cosmic-text = { path = "../../" }
 env_logger = "0.11"
-fontdb = "0.23"
+fontdb = "0.24"
 log = "0.4"
 orbclient = "0.3.50"
 unicode-segmentation = "1.12"

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 cosmic-text = { path = "../..", features = ["syntect"] }
 env_logger = "0.11"
-fontdb = "0.23"
+fontdb = "0.24"
 log = "0.4"
 softbuffer = "0.4"
 tiny-skia = "0.11"

--- a/examples/multiview/Cargo.toml
+++ b/examples/multiview/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 cosmic-text = { path = "../.." }
 env_logger = "0.11"
-fontdb = "0.23"
+fontdb = "0.24"
 log = "0.4"
 softbuffer = "0.4"
 tiny-skia = "0.11"

--- a/examples/rich-text/Cargo.toml
+++ b/examples/rich-text/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 cosmic-text = { path = "../.." }
 env_logger = "0.11"
-fontdb = "0.23"
+fontdb = "0.24"
 log = "0.4"
 softbuffer = "0.4"
 tiny-skia = "0.11"

--- a/examples/terminal/Cargo.toml
+++ b/examples/terminal/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 colored = "3.1"
 cosmic-text = { path = "../../" }
 env_logger = "0.11"
-fontdb = "0.23"
+fontdb = "0.24"
 log = "0.4"


### PR DESCRIPTION
Follows up on #517
Related to #513 

[fontdb 0.24](https://github.com/RazrFalcon/fontdb/releases/tag/v0.24.0) no longer depends on ttf-parser, so the cargo deny can be dropped. 

- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

