### PR TITLE
Store `monospace_font_ids` in a `HashSet`

### DIFF
--- a/src/font/system.rs
+++ b/src/font/system.rs
@@ -1,4 +1,4 @@
-use crate::{Attrs, Font, FontMatchAttrs, HashMap, ShapeBuffer};
+use crate::{Attrs, Font, FontMatchAttrs, HashMap, HashSet, ShapeBuffer};
 use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
 use alloc::string::String;
@@ -140,7 +140,7 @@ pub struct FontSystem {
     font_cache: HashMap<(fontdb::ID, fontdb::Weight), Option<Arc<Font>>>,
 
     /// Sorted unique ID's of all Monospace fonts in DB
-    monospace_font_ids: Vec<fontdb::ID>,
+    monospace_font_ids: HashSet<fontdb::ID>,
 
     /// Sorted unique ID's of all Monospace fonts in DB per script.
     /// A font may support multiple scripts of course, so the same ID
@@ -293,14 +293,13 @@ impl FontSystem {
         db: fontdb::Database,
         impl_fallback: impl Fallback + 'static,
     ) -> Self {
-        let mut monospace_font_ids = db
+        let monospace_font_ids = db
             .faces()
             .filter(|face_info| {
                 face_info.monospaced && !face_info.post_script_name.contains("Emoji")
             })
             .map(|face_info| face_info.id)
-            .collect::<Vec<_>>();
-        monospace_font_ids.sort();
+            .collect::<HashSet<_>>();
 
         let mut per_script_monospace_font_ids: HashMap<[u8; 4], BTreeSet<fontdb::ID>> =
             HashMap::default();
@@ -399,7 +398,7 @@ impl FontSystem {
     }
 
     pub fn is_monospace(&self, id: fontdb::ID) -> bool {
-        self.monospace_font_ids.binary_search(&id).is_ok()
+        self.monospace_font_ids.contains(&id)
     }
 
     pub fn get_monospace_ids_for_scripts(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,3 +146,8 @@ type BuildHasher = core::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 type HashMap<K, V> = std::collections::HashMap<K, V, BuildHasher>;
 #[cfg(not(feature = "std"))]
 type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasher>;
+
+#[cfg(feature = "std")]
+type HashSet<T> = std::collections::HashSet<T, BuildHasher>;
+#[cfg(not(feature = "std"))]
+type HashSet<T> = hashbrown::HashSet<T, BuildHasher>;


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This PR improves a bit on #245/#518. It doesn't address the root cause of `is_monospace` being called an obscene number of times, but still leads to roughly a 2,5x speedup for the provided benchmark in #518:

```
faces: 2303   (monospaced: 21)
Family::Monospace default resolves? true

  Monospace   / spaced text                      367.010µs/shape
  Monospace   / tight text                        39.123µs/shape
  SansSerif   / spaced text                       55.049µs/shape
  SansSerif   / tight text                        10.397µs/shape
  Name(Menlo) / spaced text                       54.303µs/shape
  Name(Menlo) / tight text                        10.407µs/shape
```
vs
```
faces: 2303   (monospaced: 21)
Family::Monospace default resolves? true

  Monospace   / spaced text                      126.665µs/shape
  Monospace   / tight text                        19.402µs/shape
  SansSerif   / spaced text                       52.179µs/shape
  SansSerif   / tight text                         9.758µs/shape
  Name(Menlo) / spaced text                       51.236µs/shape
  Name(Menlo) / tight text                         9.693µs/shape
```
